### PR TITLE
Changed doc for api-mgr api deploy

### DIFF
--- a/modules/ROOT/pages/anypoint-platform-cli-commands.adoc
+++ b/modules/ROOT/pages/anypoint-platform-cli-commands.adoc
@@ -503,7 +503,6 @@ Besides the default `--help`, `-f`/`--fields` and `-o`/`--output` options, this 
 |Value |Description | Example
 | target <id>
 | Hybrid or RTF deployment target ID. +
-Valid options are: 'ES3', 'ES5', or 'ES2015'.
 | `api-mgr api deploy --target ES5 643404`
 
 | applicationName <name>


### PR DESCRIPTION
Removed from api-mgr api deploy - Valid options are: 'ES3', 'ES5', or 'ES2015'.
This is confusing