### PR TITLE
Added back Runtime Manager API topic

### DIFF
--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -47,6 +47,7 @@
  ** xref:vpc-tutorial.adoc[Create a VPC]
  ** xref:vpc-firewall-rules-concept.adoc[About VPC Firewall Rules]
  ** xref:resolve-private-domains-vpc-task.adoc[To Resolve Private Domains in Your Internal Network]
+* xref:runtime-manager-api.adoc[Runtime Manager API]
 * xref:monitoring.adoc[Monitoring]
  ** xref:alerts-on-runtime-manager.adoc[Alerts]
  ** xref:notifications-on-runtime-manager.adoc[Notifications]

--- a/modules/ROOT/pages/runtime-manager-api.adoc
+++ b/modules/ROOT/pages/runtime-manager-api.adoc
@@ -1,0 +1,11 @@
+= About the Runtime Manager REST API
+ifndef::env-site,env-github[]
+include::_attributes.adoc[]
+endif::[]
+:keywords: cloudhub, cloudhub api, manage, api, rest
+
+The Runtime Manager REST API enables you to programmatically access much of the functionality provided by the Runtime Manager. To deploy Mule applications using the Runtime Manager REST API, see https://anypoint.mulesoft.com/exchange/portals/anypoint-platform/f1e97bc6-315a-4490-82a7-23abe036327a.anypoint-platform/arm-rest-services[REST APIs].
+
+For a more complete reference of all the operations that are supported through the API, see https://anypoint.mulesoft.com/apiplatform/anypoint-platform/#/portals/organizations/ae639f94-da46-42bc-9d51-180ec25cf994/apis/38784/versions/127446/pages/182845[API Reference 1.5].
+
+Also note that there is a xref:cloudhub-api.adoc[CloudHub API] that allows you to deploy applications to CloudHub.

--- a/modules/ROOT/pages/runtime-manager-api.adoc
+++ b/modules/ROOT/pages/runtime-manager-api.adoc
@@ -9,3 +9,7 @@ The Runtime Manager REST API enables you to programmatically access much of the 
 For a more complete reference of all the operations that are supported through the API, see https://anypoint.mulesoft.com/apiplatform/anypoint-platform/#/portals/organizations/ae639f94-da46-42bc-9d51-180ec25cf994/apis/38784/versions/127446/pages/182845[API Reference 1.5].
 
 Also note that there is a xref:cloudhub-api.adoc[CloudHub API] that allows you to deploy applications to CloudHub.
+
+== See Also
+
+xref:continuous-deployment.adoc[Continuous Deployment]


### PR DESCRIPTION
So link wouldn't be broken on docs site. This is just a temp workaround.