### PR TITLE
Update instruction to download Runtime Manager Agent

### DIFF
--- a/modules/ROOT/pages/installing-and-configuring-runtime-manager-agent.adoc
+++ b/modules/ROOT/pages/installing-and-configuring-runtime-manager-agent.adoc
@@ -18,7 +18,7 @@ The Runtime Manager Agent is installed into a Mule runtime, and is used to regis
 The latest version of the Mule runtime is bundled with the latest version of the Runtime Manager Agent. You can download the latest Mule runtime from the https://www.mulesoft.com/support-login[Customer Portal]. However, you must download and install the correct version of the Runtime Manager Agent that supports the version of Anypoint Platform you are using. The version of Runtime Manager Agent you need may be different from the version bundled with the current version of Runtime Manager. You may need to downgrade the version of the agent to support your version of the platform.
 
 If you use an older version of the Mule runtime, or an older API Gateway Runtime, or if a newer version of the Runtime Manager Agent releases in between Mule runtime releases, then you can download and install the latest version of the Runtime Manager Agent from the
-xref:release-notes::runtime-manager-agent/runtime-manager-agent-release-notes.adoc[Runtime Manager Agent release notes].
+https://www.mulesoft.com/support-login[Customer Portal].
 
 
 [NOTE]


### PR DESCRIPTION
The Runtime Manager Agent is not available for download in the release notes site anymore. It has to be downloaded from the customer support portal.