### PR TITLE
Update cloudhub-architecture.adoc

### DIFF
--- a/modules/ROOT/pages/cloudhub-architecture.adoc
+++ b/modules/ROOT/pages/cloudhub-architecture.adoc
@@ -32,7 +32,7 @@ image::architecture-diagram.png[]
 |===
 
 [NOTE]
-You can view the live status and detailed service history for the Runtime Manager console, platform services, and the CloudHub worker cloud on http://trust.mulesoft.com/[trust.mulesoft.com].
+You can view the live status and detailed service history for the Runtime Manager console, platform services, and the CloudHub worker cloud on https://status.mulesoft.com/[status.mulesoft.com] for the default (US hosted) Control Plane and https://eu1-status.mulesoft.com/[eu1-status.mulesoft.com] for the EU Control Plane.
 
 === Integration Applications
 


### PR DESCRIPTION
Fix url for status.mulesoft.com and add EU Control Plane details