### PR TITLE
Update virtual-private-cloud.adoc

### DIFF
--- a/modules/ROOT/pages/virtual-private-cloud.adoc
+++ b/modules/ROOT/pages/virtual-private-cloud.adoc
@@ -5,7 +5,7 @@ endif::[]
 
 The Virtual Private Cloud (VPC) offering allows you to create a virtual, private, and isolated network segment in the cloud to host your CloudHub workers.
 
-Connecting to your CloudHub VPC extends your corporate intranet and allows CloudHub workers to access resources behind your corporate firewall. You can connect on-premises data centers through a secured VPN tunnel, or a private AWS VPC through VPN peering, or by using AWS Direct Connect.
+Connecting to your CloudHub VPC extends your corporate intranet and allows CloudHub workers to access resources behind your corporate firewall. You can connect on-premises data centers through a secured VPN tunnel, or a private AWS VPC through VPC peering, or by using AWS Direct Connect.
 
 The base VPC subscription includes two VPCs and each VPC can be associated with multiple environments. This allows you, for example, to have one isolated network for your production environment, and another for your QA and staging.
 


### PR DESCRIPTION
I believe "VPC" peering is meant here and not "VPN" peering.

According to AWS
"AWS uses the existing infrastructure of a VPC to create a VPC peering connection; it is neither a gateway nor a VPN connection, and does not rely on a separate piece of physical hardware. There is no single point of failure for communication or a bandwidth bottleneck."  https://docs.aws.amazon.com/vpc/latest/peering/what-is-vpc-peering.html

AWS explicitly states that VPC peering it is not a VPN connection.