### PR TITLE
Added Note that replay is not supported for Mule 4

### DIFF
--- a/modules/ROOT/pages/insight.adoc
+++ b/modules/ROOT/pages/insight.adoc
@@ -182,9 +182,7 @@ After investigating the logs and resolving the issue that caused the transaction
 
 [NOTE]
 ====
-At the moment, the replay feature is only available for Mule 3 applications.
-
-Replay only works for flows that have inbound endpoints.
+Currently, the replay feature is supported only for Mule 3 applications and for flows that have inbound endpoints.
 ====
 
 Click the replay icon (circular arrow) next to the first event in the failed transaction to replay it:

--- a/modules/ROOT/pages/insight.adoc
+++ b/modules/ROOT/pages/insight.adoc
@@ -180,7 +180,12 @@ image::chexcmsg.png[CHExcMsg]
 
 After investigating the logs and resolving the issue that caused the transaction failure – for example, by purchasing more API capacity  – you can simply replay the transaction.
 
-*Note*: Replay only works for flows that have inbound endpoints.
+[NOTE]
+====
+At the moment, the replay feature is only available for Mule 3 applications.
+
+Replay only works for flows that have inbound endpoints.
+====
 
 Click the replay icon (circular arrow) next to the first event in the failed transaction to replay it:
 


### PR DESCRIPTION
At the moment, replay feature is only available for Mule 3 applications. I added a note stating this as many users would expect to see the replay button on their mule 4 apps.