### PR TITLE
Update virtual-private-cloud.adoc

### DIFF
--- a/modules/ROOT/pages/virtual-private-cloud.adoc
+++ b/modules/ROOT/pages/virtual-private-cloud.adoc
@@ -29,7 +29,7 @@ image::vpc-1-1-deployment.png[1:1 VPC Deployment]
 
 === Connect a Single Anypoint VPC to Two Remote Locations
 
-A strict 1:1 relationship between a VPC and remote location is not necessary. In this example, a single VPC is connected to public IP addresses at two remote locations. This means that you are using both of the VPC licenses that are included in the base VPC subscription for a single VPC, which leaves no licenses for connectivity to the second VPC. 
+A strict 1:1 relationship between a VPC and remote location is not necessary. In this example, a single VPC is connected to public IP addresses at two remote locations. This means that you are using both of the VPN licenses that are included in the base VPC subscription for a single VPC, which leaves no licenses for connectivity to the second VPC. 
 
 image::vpc-one-to-two-remote-locations.png[One VPC Connecting to Two Remote Locations]
 


### PR DESCRIPTION
VPC and VPN are used interchangeably and this causes confusion. This is being done in more than one place - I edited one to give Git diff-highlight; others might need to be reviewed as well

My understanding is that each VPC license includes with 2 ***VPNs***, and that additional ***VPN*** in a given ___VPC___ have associated license costs.

A VPN is not the same as . VPC