### PR TITLE
Fix broken table syntax

### DIFF
--- a/modules/ROOT/pages/installing-and-configuring-runtime-manager-agent.adoc
+++ b/modules/ROOT/pages/installing-and-configuring-runtime-manager-agent.adoc
@@ -861,17 +861,14 @@ There are two static IPs that must be whitelisted to access the mule-manager hos
 |*EU*|*mule-manager.eu1.anypoint.mulesoft.com* |18.194.245.32
 |===
 
-[NOTE]
-====
-The following DNS endpoints do not have static IP addresses:
+The following DNS endpoints do not have static IP addresses: 
 
 [%header,cols="2*a"]
-|===
-|Region |Name
+|====
+|Region | Name
 |*US*|*runtime-manager.anypoint.mulesoft.com*
 |*EU*|*runtime-manager.eu1.anypoint.mulesoft.com*
-|===
-====
+|====
 
 *Dynamic IPs*
 


### PR DESCRIPTION
This table is currently broken:
<img width="606" alt="test" src="https://user-images.githubusercontent.com/16763154/53053470-361f7400-3480-11e9-8e99-36e5575528f3.png">

I tried fixing this table inside the admonition block, however no syntax seems to do the trick.

∙ Remove the broken table inside the admonition block.
