### PR TITLE
DOCS-1868 TLS namespace to API Manager example

### DIFF
--- a/modules/ROOT/pages/building-an-https-service.adoc
+++ b/modules/ROOT/pages/building-an-https-service.adoc
@@ -104,6 +104,7 @@ Your configuration should look similar to the following:
 ----
 <?xml version="1.0" encoding="UTF-8"?>
 <mule xmlns="http://www.mulesoft.org/schema/mule/core"
+      xmlns:tls="http://www.mulesoft.org/schema/mule/tls"
       xmlns:http="http://www.mulesoft.org/schema/mule/http"
       xmlns:api-platform-gw="http://www.mulesoft.org/schema/mule/api-platform-gw"
       xmlns:expression-language="http://www.mulesoft.org/schema/mule/expression-language-gw"
@@ -111,7 +112,7 @@ Your configuration should look similar to the following:
       xsi:schemaLocation="http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd
 http://www.mulesoft.org/schema/mule/http http://www.mulesoft.org/schema/mule/http/current/mule-http.xsd
 http://www.mulesoft.org/schema/mule/api-platform-gw http://www.mulesoft.org/schema/mule/api-platform-gw/current/mule-api-platform-gw.xsd
-http://www.mulesoft.org/schema/mule/expression-language-gw http://www.mulesoft.org/schema/mule/expression-language-gw/current/mule-expression-language-gw.xsd">
+http://www.mulesoft.org/schema/mule/expression-language-gw http://www.mulesoft.org/schema/mule/expression-language-gw/current/mule-expression-language-gw.xsd http://www.mulesoft.org/schema/mule/tls http://www.mulesoft.org/schema/mule/tls/current/mule-tls.xsd">
 
     <configuration defaultProcessingStrategy="non-blocking" />
 


### PR DESCRIPTION
DOCS https://docs.mulesoft.com/runtime-manager/building-an-https-service#services-under-api-manager-proxies provides an example on HTTPS configuration.
The two following entries would need to be added to support TLS configuration: 

http://www.mulesoft.org/schema/mule/tls http://www.mulesoft.org/schema/mule/tls/current/mule-tls.xsd
xmlns:tls="http://www.mulesoft.org/schema/mule/tls"