### PR TITLE
fix link title

### DIFF
--- a/modules/ROOT/pages/cloudhub-networking-guide.adoc
+++ b/modules/ROOT/pages/cloudhub-networking-guide.adoc
@@ -91,7 +91,7 @@ You can assign Static IP to applications with multiple workers. However, it is n
 
 Depending on what region you deploy your application in, the DNS record and the load balancer for your integration may change. The following table summarizes what DNS records are available for your application in each region:
 
-https://anypoint.mulesoft.com[Anypoint Platform] for the U.S. control plane 
+https://anypoint.mulesoft.com[Anypoint Platform] for the U.S. control plane
 covers the following regions.
 
 [%header,cols="2*a"]
@@ -112,7 +112,7 @@ covers the following regions.
 
 |===
 
-https://eu1.anypoint.mulesoft.com[EU Control Plane] for the EU control plane 
+https://eu1.anypoint.mulesoft.com[Anypoint Platform] for the EU control plane 
 covers the following regions.
 
 [%header,cols="2*a"]
@@ -123,8 +123,8 @@ covers the following regions.
 
 |===
 
-Note that DNS records are unique to each control plane. Though the EU control plane 
-supports some of the same regions that the U.S. control plane supports, the DNS records 
+Note that DNS records are unique to each control plane. Though the EU control plane
+supports some of the same regions that the U.S. control plane supports, the DNS records
 are different. For more on the EU control plane, see
 xref:eu-control-plane::index.adoc[About the EU Control Plane].
 


### PR DESCRIPTION
Fixing  glaring “typo”. I need to change “EU Control Plane for the EU control” to “Anypoint Platform for the EU control”. I forgot to update the link. Can you approve it when I get that out?