### PR TITLE
Warning about wrong usage

### DIFF
--- a/modules/ROOT/pages/installing-and-configuring-runtime-manager-agent.adoc
+++ b/modules/ROOT/pages/installing-and-configuring-runtime-manager-agent.adoc
@@ -11,14 +11,14 @@ image:logo-hybrid-active.png[link="/runtime-manager/deployment-strategies", titl
 image:logo-server-active.png[link="/runtime-manager/deployment-strategies", title="Anypoint Platform Private Cloud Edition"]
 image:logo-pcf-disabled.png[link="/runtime-manager/deployment-strategies", title="Pivotal Cloud Foundry"]
 
-The Runtime Manager Agent is installed into a Mule runtime engine, and is used to register the Mule with Runtime Manager. The Mule runtime engine is then registered and controlled by Runtime Manager within a specific environment of a specific Anypoint Platform business group.
+The Runtime Manager Agent is installed into a Mule runtime engine (Mule), and is used to register the Mule with Runtime Manager. Once the Mule runtime engine is registered, it can be managed by Runtime Manager within the specific environment and Anypoint Platform business group in which it was registered. A Mule can't be registered with multiple Runtime Manager business groups or environments.
 
-The latest version of the Mule runtime engine is bundled with the latest version of the Runtime Manager agent. You can download the latest Mule runtime engine from the https://www.mulesoft.com/support-login[Customer Portal].
+The latest version of Mule is bundled with the latest version of the Runtime Manager agent. You can download the latest version of Mule from the https://www.mulesoft.com/support-login[Customer Portal].
 
 [NOTE]
-You must download and install the version of the Runtime Manager agent that supports the version of Anypoint Platform you are using. The version of Runtime Manager agent you need may be different from the version bundled with the current version of Runtime Manager. You may need to downgrade the version of the agent to support your version of the platform.
+You must download and install the version of the Runtime Manager agent that supports the version of Anypoint Platform Runtime Manager you are using. The version of Runtime Manager agent you need may be different from the version bundled with the current version of Runtime Manager. You may need to downgrade the version of Runtime Manager agent to support your version of Anypoint Platform.
 
-If you use an earlier version of the Mule runtime engine, or an earlier API gateway, or if a later version of the Runtime Manager agent releases in between Mule runtime engine releases, then you can download and install the latest version of the Runtime Manager Agent from the
+If you use an earlier version of the Mule runtime engine, or an earlier API gateway, or if a later version of the Runtime Manager agent is released in between Mule releases, then you can download and install the latest version of the Runtime Manager agent from the
 https://www.mulesoft.com/support-login[Customer Portal].
 
 
@@ -305,7 +305,7 @@ globalConfiguration:
 ====
 Do not register a single Mule runtime engine with multiple Runtime Manager business groups or environments.
 
-Do not duplicate a Mule runtime engine after registering it with Anypoint Runtime Manager. Each Mule must be registered individually.
+Each individual Mule can be registered with Runtime Manager only once. Do not duplicate a Mule runtime engine after registering it with Anypoint Runtime Manager. 
 
 Do not register a Mule runtime engine with both an older xref:mule-management-console::index.adoc[Mule Management Console (MMC)] and Runtime Manager. If the Mule runtime engine is currently managed in MMC, first unregister the Mule runtime engine with MMC before running the `amc_setup -H` script.
 ====

--- a/modules/ROOT/pages/installing-and-configuring-runtime-manager-agent.adoc
+++ b/modules/ROOT/pages/installing-and-configuring-runtime-manager-agent.adoc
@@ -305,6 +305,8 @@ globalConfiguration:
 ====
 It is not supported to register a Mule runtime engine with multiple Runtime Manager business groups or environments.
 
+It is not supported to duplicate a Mule runtime after having registered it against Anypoint Runtime Manager. Each runtime should be registered individually.
+
 It is also not supported to register a Mule runtime engine with both an older xref:mule-management-console::index.adoc[Mule Management Console (MMC)] and Runtime Manager. If the Mule runtime engine is currently managed in MMC, you should first unregister the Mule runtime engine with MMC before running the `amc_setup -H` script.
 ====
 

--- a/modules/ROOT/pages/installing-and-configuring-runtime-manager-agent.adoc
+++ b/modules/ROOT/pages/installing-and-configuring-runtime-manager-agent.adoc
@@ -303,11 +303,11 @@ globalConfiguration:
 
 [WARNING]
 ====
-It is not supported to register a Mule runtime engine with multiple Runtime Manager business groups or environments.
+Do not register a single Mule runtime engine with multiple Runtime Manager business groups or environments.
 
-It is not supported to duplicate a Mule runtime after having registered it against Anypoint Runtime Manager. Each runtime should be registered individually.
+Do not duplicate a Mule runtime engine after registering it with Anypoint Runtime Manager. Each Mule must be registered individually.
 
-It is also not supported to register a Mule runtime engine with both an older xref:mule-management-console::index.adoc[Mule Management Console (MMC)] and Runtime Manager. If the Mule runtime engine is currently managed in MMC, you should first unregister the Mule runtime engine with MMC before running the `amc_setup -H` script.
+Do not register a Mule runtime engine with both an older xref:mule-management-console::index.adoc[Mule Management Console (MMC)] and Runtime Manager. If the Mule runtime engine is currently managed in MMC, first unregister the Mule runtime engine with MMC before running the `amc_setup -H` script.
 ====
 
 [TIP]


### PR DESCRIPTION
Some customers are registering a runtime, and then duplicating the server to have many instances of it managed by the platform. Although the issue this wrong practice brings, it will be fixed to avoid the consequences in https://www.mulesoft.org/jira/browse/PCCR-6623
It's better to have this stated explicitly