### PR TITLE
Protocol should be HTTP as it's insecure

### DIFF
--- a/modules/ROOT/pages/installing-and-configuring-runtime-manager-agent.adoc
+++ b/modules/ROOT/pages/installing-and-configuring-runtime-manager-agent.adoc
@@ -448,7 +448,7 @@ This option, configurable on the installation command through the '-I' parameter
 |`-I`
 
 `--insecure`
-|Configures the Runtime Manager agent to use an unencrypted connection. It is valid for the REST transport only. You can interact with the API using a browser or other tool for making HTTP requests. The default TCP port is 9999, so you can connect to the Runtime Manager agent at the base URL `+https://localhost:9999/mule/agent/+`.
+|Configures the Runtime Manager agent to use an unencrypted connection. It is valid for the REST transport only. You can interact with the API using a browser or other tool for making HTTP requests. The default TCP port is 9999, so you can connect to the Runtime Manager agent at the base URL `+http://localhost:9999/mule/agent/+`.
 
 |===
 


### PR DESCRIPTION
When configuring insecure connection to the agent, it uses HTTP, not HTTPS... i have already tested this.