### PR TITLE
fix links

### DIFF
--- a/modules/ROOT/pages/cloudhub.adoc
+++ b/modules/ROOT/pages/cloudhub.adoc
@@ -15,7 +15,7 @@ http://www.mulesoft.com/cloudhub/ipaas-cloud-based-integration-demand[CloudHub] 
 
 image::logo-app.png[app]
 
-* See xref:runtime-manager:deploying-to-cloudhub.adoc[Deploying to CloudHub].
+* See xref:deploying-to-cloudhub.adoc[Deploying to CloudHub].
 * See xref:building-an-https-service.adoc[Building an HTTPS Service on CloudHub] include HTTPS support in this application.
 
 [TIP]
@@ -63,7 +63,7 @@ Learn how you can manage an application that is currently running in CloudHub:
 
 === Manage Applications in Runtime Manager
 
-Maintain your applications on CloudHub through the xref:runtime-manager::index.adoc[Runtime Manager], an intuitive cloud console where you can xref:managing-deployed-applications.adoc[manage] and xref:monitoring.adoc[monitor] every aspect of your applications in a centralized location. 
+Maintain your applications on CloudHub through the xref:index.adoc[Runtime Manager], an intuitive cloud console where you can xref:managing-deployed-applications.adoc[manage] and xref:monitoring.adoc[monitor] every aspect of your applications in a centralized location. 
 
 [NOTE]
 You can view the live status and detailed service history for the Runtime Manager console, platform services, and the CloudHub worker cloud on http://trust.mulesoft.com/[`trust.mulesoft.com`].

--- a/modules/ROOT/pages/custom-application-alerts.adoc
+++ b/modules/ROOT/pages/custom-application-alerts.adoc
@@ -14,7 +14,7 @@ image:logo-pcf-disabled.png[link="/runtime-manager/deployment-strategies", title
 
 == Prerequisites
 
-* xref:general:runtime-manager:deploying-to-cloudhub.adoc[Deploy to CloudHub]
+* xref:deploying-to-cloudhub.adoc[Deploy to CloudHub]
 * xref:6@studio::enabling-maven-support-for-a-studio-project.adoc[Mavenize your project in Studio]
 
 == How to Use Notifications

--- a/modules/ROOT/pages/deploying-to-cloudhub.adoc
+++ b/modules/ROOT/pages/deploying-to-cloudhub.adoc
@@ -406,7 +406,6 @@ If an error occurs and the application cannot be deployed, the application statu
 
 == See Also
 
-* xref:general:runtime-manager:deploying-to-cloudhub.adoc[Deploying to CloudHub]
 * xref:cloudhub.adoc[CloudHub]
 * xref:managing-deployed-applications.adoc[Managing Deployed Applications]
 * xref:managing-applications-on-cloudhub.adoc[Managing Applications on CloudHub]


### PR DESCRIPTION
Here's the links I fixed & checked:

repo: //github.com/mulesoft/docs-runtime-manager | branch: latest | component: runtime-manager | version: master:

  1. path: modules/ROOT/pages/cloudhub.adoc |  xref: runtime-manager:deploying-to-cloudhub.adoc
  2. path: modules/ROOT/pages/custom-application-alerts.adoc |  xref: general:runtime-manager:deploying-to-cloudhub.adoc
  3. path: modules/ROOT/pages/deploying-to-cloudhub.adoc |  xref: general:runtime-manager:deploying-to-cloudhub.adoc
