### PR TITLE
Rewrite prerequesites for alerts in CloudHub

### DIFF
--- a/modules/ROOT/pages/custom-application-alerts.adoc
+++ b/modules/ROOT/pages/custom-application-alerts.adoc
@@ -14,8 +14,12 @@ image:logo-pcf-disabled.png[link="/runtime-manager/deployment-strategies", title
 
 == Prerequisites
 
-* xref:deploying-to-cloudhub.adoc[Deploy to CloudHub]
-* xref:6@studio::enabling-maven-support-for-a-studio-project.adoc[Mavenize your project in Studio]
+* Your application must be deployed to CloudHub. +
+xref:deploying-to-cloudhub.adoc[Deploy to CloudHub]
+* You Mule project must be mavenized. +
+** If you are using Studio 6.x and earlier, make sure you xref:6@studio::enabling-maven-support-for-a-studio-project.adoc[Mavenize your project in Studio].
+** All projects in Studio 7.x and later are mavenized by default.
+
 
 == How to Use Notifications
 


### PR DESCRIPTION
This commit also adds clarification that mavenization of projects is the 
default in Studio 7 and cannot be opt-out