### PR TITLE
Corrected as per feedback on pull request #136

### DIFF
--- a/modules/ROOT/pages/installing-and-configuring-runtime-manager-agent.adoc
+++ b/modules/ROOT/pages/installing-and-configuring-runtime-manager-agent.adoc
@@ -537,7 +537,7 @@ transports:
   rest.agent.transport:
     restSecurity:
       keyStoreFile: server.jks
-      keystorePassword: P@ssword
+      keyStorePassword: P@ssword
       keyStoreAlias: serverkey
       keyStoreAliasPassword: P@ssword
     port: 9999
@@ -549,9 +549,9 @@ services:
     frequencyTimeUnit: MINUTES
 ----
 
-=== Configuring a Mule Runtime for Two-Way TLS
+=== Configuring a Mule Runtime for Two-Way TLS Without Anypoint Control Plane
 
-Here is an example of configuring two-way TLS with the `amc_setup -S` option.
+Here is an example of configuring two-way TLS with the `amc_setup -S` option. When using this option, the Mule Runtime is not connected to Anypoint Control Plane.
 
 The steps to configure TLS are:
 
@@ -660,6 +660,119 @@ The `/security/cacerts.jks` truststore file is imported into the `$MULE_HOME/con
 The default truststore was renamed `anypoint-truststore.jks` in Runtime Manager agent version 1.10.0 and later. In earlier versions of Runtime Manager agent, the default truststore was named `truststore.jks`. 
 
 . Restart the Mule runtime engine, and verify the Runtime Manager agent REST interface starts up successfully. Add SSL debugging to the Mule runtime engine logging. `./mule -M-Djavax.net.debug=all`
+
+
+=== Configuring a Mule Runtime for Two-Way TLS with the Mule Runtime managed by Anypoint Control Plane
+
+Here is an example of configuring two-way TLS with the Mule Runtime connected to Anypoint Control Plane.
+
+The steps to configure TLS are:
+
+. Generate a keystore (public/private key pair) to identify the Runtime Manager agent (server). Set the CN to match the Runtime Manager agent's hostname or IP Address.
+
++
+[source,console,linenums]
+----
+echo "Generate a new keystore to identify the Runtime Manager Agent. Use CN=localhost"
+
+keytool -keystore rmakeystore.jks -keypass mulesoft -storepass mulesoft -genkey -keyalg RSA -keypass mulesoft -noprompt \
+-alias rma \
+-dname "CN=localhost, OU=Runtime Manager Agent, O=MuleSoft, L=San Francisco, S=Califorina, C=US"
+----
+
+. Export the Runtime Manager agent's certificate (only the public key) to a DES formatted certificate file
+
++
+[source,console,linenums]
+----
+echo "Export the rma alias' certificate from the rmakeystore.jks key store"
+keytool -export -alias rma -file rma.crt -keystore rmakeystore.jks -storepass mulesoft
+----
+
+
+
+. For each REST client that will connect to the Runtime Manager agent, generate a keystore (public/private key pair) to identify the REST client.
+
++
+[source,console,linenums]
+----
+echo "Generate a new keystore to be used by client requestors. Use CN=localhost"
+keytool -keystore clientkeystore.jks -storepass mulesoft -genkey -keyalg RSA -keypass mulesoft -noprompt \
+-alias client \
+-dname "CN=localhost, OU=RMA Client, O=MuleSoft, L=San Francisco, S=California, C=US"
+----
+
+
+. Export the REST client's certificate (the public key only) to a DES formatted certificate file.
+
++
+[source,console,linenums]
+----
+echo "Export the client alias' certificate from the clientkeystore.jks key store"
+keytool -export -alias client -file client.crt -keystore clientkeystore.jks -storepass mulesoft
+----
+
+. Since these are self-signed certificate files, the client can't validate them with a Certificate Authority (CA), so you must create a truststore file containing both the client and RMA certificates (public keys) to emulate CA signing both of these certificates. In a production environment, the server and client certificates would both be signed by a trusted CA, then published or shared with the client and server machines.
+
++
+[source,console,linenums]
+----
+echo "Import client and server public keys into a common cacerts.jks truststore file"
+
+keytool -import -v -trustcacerts -alias rma -file rma.crt -keystore cacerts.jks -keypass mulesoft -storepass mulesoft -noprompt
+
+keytool -import -v -trustcacerts -alias client -file client.crt -keystore cacerts.jks -keypass mulesoft -storepass mulesoft -noprompt
+----
+
+. Take a backup of anypoint-truststore.jks and mule-agent.yml file
+
++
+[source,console,linenums]
+----
+cp anypoint-truststore.jks anypoint-truststure.jks.bkp
+cp mule-agent.yml mule-agent.yml.bkp
+----
+
+. Export the Anypoint Platform's certificate to a DES formatted certificate file. If prompted for a password just press enter.
+
++
+[source,console,linenums]
+----
+keytool -export -alias hybrid -file hybrid.crt -keystore anypoint-truststore.jks
+----
+
+. Since these are self-signed certificate files, the client can't validate them with a Certificate Authority (CA), so you must create a truststore file containing both the client and RMA certificates (public keys) to emulate CA signing both of these certificates, as well as Anypoint Platform's certificate in order to retain the connectivity with the Control Plane. In a production environment, the server and client certificates would both be signed by a trusted CA, then published or shared with the client and server machines.
+
+----
+keytool -import -v -trustcacerts -alias rma -file rma.crt -keystore cacerts.jks -keypass mulesoft -storepass mulesoft -noprompt
+keytool -import -v -trustcacerts -alias client -file client.crt -keystore cacerts.jks -keypass mulesoft -storepass mulesoft -noprompt
+keytool -import -v -trustcacerts -alias hybrid -file hybrid.crt -keystore cacerts.jks -keypass mulesoft -storepass mulesoft -noprompt
+----
+
+. Shut down the mule server and modify mule-agent.yml file to configure secure REST API endpoint. 
+
+----
+transports:
+  rest.agent.transport:
+    restSecurity:
+      keyStoreFile: rmakeystore.jks
+      keyStorePassword: mulesoft
+      keyStoreAlias: rma
+      keyStoreAliasPassword: mulesoft
+    port: 9995
+----
+
+. Rename the newly created cacerts.jks file as anypoint-truststore.jks. This file will function as your new trustustrore for RMA as well as Anypoint Platform connectivity.
+----
+mv cacerts.jks anypoint-truststore.jks
+----
+
+[NOTE]
+The default truststore was renamed `anypoint-truststore.jks` in Runtime Manager agent version 1.10.0 and later. In earlier versions of Runtime Manager agent, the default truststore was named `truststore.jks`. 
+
+. Start the Mule runtime engine, and verify the Runtime Manager agent REST interface starts up successfully as well as verify that it is still connected to ARM in Anypoint Platform. Add SSL debugging to the Mule runtime engine logging. `./mule -M-Djavax.net.debug=all`
+
+
 
 ==== Submit Two-Way TLS REST Requests
 


### PR DESCRIPTION
@mcocaro as per feedback on pull request #136, I have created a separate section for runtime connected to the control plane with an option to setup two-way TLS for runtime manager.  I will withdraw the earlier pull request
@valkyrie69 FYI: