### PR TITLE
adding page alias for deploy-to-server 

### DIFF
--- a/modules/ROOT/pages/deployment-strategies.adoc
+++ b/modules/ROOT/pages/deployment-strategies.adoc
@@ -2,6 +2,7 @@
 ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
+:page-aliases: general:getting-started:deploy-to-server.adoc
 
 Runtime Manager allows you to deploy your Mule applications to Mule instances in several ways, depending on your Mule runtime server topology. These are the different deployment strategies available to date.
 


### PR DESCRIPTION
removing /general/getting-started/deploy-to-server.adoc, so need a page alias to this topic.

PR for removed topic: https://github.com/mulesoft/docs-general/pull/39