### PR TITLE
Typo in runtime-mgr pcf-application deploy options

### DIFF
--- a/modules/ROOT/pages/anypoint-platform-cli-commands.adoc
+++ b/modules/ROOT/pages/anypoint-platform-cli-commands.adoc
@@ -1753,7 +1753,7 @@ Besides the default `--help`, `-f`/`--fields` and `-o`/`--output` options, this 
 | `--property [property]` | Set a property (`name:value`). Can be specified multiple times
 | `--propertiesFile [propertiesFile]` | Overwrite all properties with values from this file. The file format is 1 or more lines in name=value format
 | `--binding [binding]` | Set a service binding (`serviceName.key:value`). Can be specified multiple times
-| `--bindingsFile [sindingsFile]` | Overwrite all properties with values from this file. The file format is 1 or more lines in `serviceName.key:value` format
+| `--bindingsFile [bindingsFile]` | Overwrite all properties with values from this file. The file format is 1 or more lines in `serviceName.key:value` format
 |===
 
 === runtime-mgr pcf-application describe-json


### PR DESCRIPTION
Changed 'sindingsFile' to 'bindingsFile'