### PR TITLE
DOCS-6980 Removed download link for API Analytics Handlers

### DIFF
--- a/modules/ROOT/pages/sending-api-analytics-from-arm-to-db.adoc
+++ b/modules/ROOT/pages/sending-api-analytics-from-arm-to-db.adoc
@@ -12,7 +12,7 @@ image:logo-pcf-disabled.png[link="/runtime-manager/deployment-strategies", title
 
 You can configure Runtime Manager agent to store HTTP API analytics data from Mule apps running on the API gateway runtime in a database.
 
-Sending data to third-party software is only available for applications deployed to local servers.
+Sending data to third-party software is available only for applications deployed to local servers.
 It is not available for applications that you deploy to CloudHub using Runtime Manager.
 
 For information about sending this data to Splunk, ELK, or another third-party software, see xref:sending-data-from-arm-to-external-analytics-software.adoc[Export Data to External Analytics Tools].

--- a/modules/ROOT/pages/sending-api-analytics-from-arm-to-db.adoc
+++ b/modules/ROOT/pages/sending-api-analytics-from-arm-to-db.adoc
@@ -19,6 +19,8 @@ For information about sending this data to Splunk, ELK, or another third-party s
 
 == Prerequisites
 
+Ensure that the following software is installed:
+
 * API gateway standalone version 2.1.0 or later
 * Runtime Manager agent version 1.3.0 or later
 

--- a/modules/ROOT/pages/sending-api-analytics-from-arm-to-db.adoc
+++ b/modules/ROOT/pages/sending-api-analytics-from-arm-to-db.adoc
@@ -10,29 +10,37 @@ image:logo-hybrid-active.png[link="/runtime-manager/deployment-strategies", titl
 image:logo-server-active.png[link="/runtime-manager/deployment-strategies", title="Anypoint Platform Private Cloud Edition"]
 image:logo-pcf-disabled.png[link="/runtime-manager/deployment-strategies", title="Pivotal Cloud Foundry"]
 
-The HTTP API analytics produced by applications running on the API gateway runtime can be easily stored in a database by configuring a few settings.
+You can configure Runtime Manager agent to store HTTP API analytics data from Mule apps running on the API gateway runtime in a database.
 
-[NOTE]
-====
-Sending data to third party software is a feature that is currently only available for applications deployed to local servers. It is not available for applications that you deploy via the Runtime Manager to xref:cloudhub.adoc[CloudHub]. See xref:deployment-strategies.adoc[Deployment Strategies].
-====
+Sending data to third-party software is only available for applications deployed to local servers.
+It is not available for applications that you deploy to CloudHub using Runtime Manager.
 
-To see how to send this same information to Splunk, ELK or other third party software, see xref:sending-data-from-arm-to-external-analytics-software.adoc[Sending data from Runtime Manager to External Analytics Software].
+For information about sending this data to Splunk, ELK, or another third-party software, see xref:sending-data-from-arm-to-external-analytics-software.adoc[Export Data to External Analytics Tools].
 
 == Prerequisites
 
-* API gateway standalone – version 2.1.0 or later
-* Runtime Manager agent plugin version 1.3.0 or later
+* API gateway standalone version 2.1.0 or later
+* Runtime Manager agent version 1.3.0 or later
 
-== Install the Runtime Manager Agent
+== Install or Update Runtime Manager Agent
 
-The Runtime Manager agent is in charge of sending messages out of Mule. To send event information to third party software, you must have version 1.3.0 or later of the Runtime Manager agent.
+Runtime Manager agent sends messages from Mule runtime engine.
+To send event information to third-party software, you must have version 1.3.0 or later of Runtime Manager agent.
 
-For help installing the agent, see xref:installing-and-configuring-runtime-manager-agent.adoc[Installing and Configuring Runtime Manager Agent].
+For information about updating the agent, see xref:installing-and-configuring-runtime-manager-agent.adoc[Install or Update Runtime Manager Agent].
 
 == Install API Analytics Tracking Database Internal Handlers
 
-Download http://mule-agent.s3.amazonaws.com/1.5.1/mule-agent-internal-handlers-db-1.5.1.zip[the API Analytics Tracking Database Internal Handlers] and unzip them in the `{MULE_HOME}/plugins/mule-agent-plugin/lib/modules` folder.
+Depending on your version of Mule agent, you might need to install the API Analytics Tracking Database Internal Handlers ZIP file.
+
+For Mule agent versions later than 1.14.3 and 2.4.5, you don't need to install the ZIP file.
+The required JAR files are included in the Mule agent plugin.
+
+For Mule agent versions earlier than 1.14.3 and 2.4.5:
+
+. Request the API Analytics Tracking Database Internal Handlers ZIP file (`mule-agent-internal-handlers-db-1.5.1.zip`) from Support.
+. Extract the ZIP file to the `{MULE_HOME}/plugins/mule-agent-plugin/lib/modules` folder.
+
 
 == Agent Configurable Fields
 
@@ -280,9 +288,10 @@ ALTER TABLE MULE_API_ANALYTICS ALTER COLUMN policy_violation_policy_id VARCHAR(5
 
 == See Also
 
-* See other ways you can xref:monitoring.adoc[Monitor Applications]
-* xref:managing-servers.adoc[Managing Servers]
-* Learn how to first xref:deploying-to-your-own-servers.adoc[Deploy Applications to your Own Servers]
-* xref:managing-deployed-applications.adoc[Managing Deployed Applications] contains more information on how to manage your application once deployed
-* xref:managing-applications-on-your-own-servers.adoc[Managing Applications on Your Own Servers] contains more information specific to on-premise deployments
-* A https://anypoint.mulesoft.com/exchange/portals/anypoint-platform/f1e97bc6-315a-4490-82a7-23abe036327a.anypoint-platform/arm-rest-services[REST APIs] is also available for deployment to your servers.
+* xref:monitoring.adoc[Monitoring Applications and Servers]
+* xref:sending-data-from-arm-to-external-analytics-software.adoc[Export Data to External Analytics Tools]
+* xref:managing-servers.adoc[Servers, Server Groups, and Clusters]
+* xref:deploying-to-your-own-servers.adoc[Deploying to Your Own Servers]
+* xref:managing-deployed-applications.adoc[Manage Deployed Applications]
+* xref:managing-applications-on-your-own-servers.adoc[Managing Applications on Your Own Servers]
+* https://anypoint.mulesoft.com/exchange/portals/anypoint-platform/f1e97bc6-315a-4490-82a7-23abe036327a.anypoint-platform/arm-rest-services[REST API]

--- a/modules/ROOT/pages/sending-api-analytics-from-arm-to-db.adoc
+++ b/modules/ROOT/pages/sending-api-analytics-from-arm-to-db.adoc
@@ -10,7 +10,7 @@ image:logo-hybrid-active.png[link="/runtime-manager/deployment-strategies", titl
 image:logo-server-active.png[link="/runtime-manager/deployment-strategies", title="Anypoint Platform Private Cloud Edition"]
 image:logo-pcf-disabled.png[link="/runtime-manager/deployment-strategies", title="Pivotal Cloud Foundry"]
 
-You can configure Runtime Manager agent to store HTTP API analytics data from Mule apps running on the API gateway runtime in a database.
+You can configure Runtime Manager agent to store in a database HTTP API analytics data from Mule apps running on the API gateway runtime.
 
 Sending data to third-party software is available only for applications deployed to local servers.
 It is not available for applications that you deploy to CloudHub using Runtime Manager.
@@ -23,24 +23,27 @@ Ensure that the following software is installed:
 
 * API gateway standalone version 2.1.0 or later
 * Runtime Manager agent version 1.3.0 or later
-
-== Install or Update Runtime Manager Agent
-
-Runtime Manager agent sends messages from Mule runtime engine.
-To send event information to third-party software, you must have version 1.3.0 or later of Runtime Manager agent.
-
++
 For information about updating the agent, see xref:installing-and-configuring-runtime-manager-agent.adoc[Install or Update Runtime Manager Agent].
 
-== Install API Analytics Tracking Database Internal Handlers
 
-Depending on your version of Mule agent, you might need to install the API Analytics Tracking Database Internal Handlers ZIP file.
+== Install API Analytics-Tracking Database Internal Handlers
 
-For Mule agent versions later than 1.14.3 and 2.4.5, you don't need to install the ZIP file.
-The required JAR files are included in the Mule agent plugin.
+Depending on your version of Runtime Manager agent, you might need to install the API Analytics-Tracking Database Internal Handlers ZIP file.
 
-For Mule agent versions earlier than 1.14.3 and 2.4.5:
+For the following agent versions, you don't need to install the ZIP file because the required JAR files are included in the agent plugin:
 
-. Request the API Analytics Tracking Database Internal Handlers ZIP file (`mule-agent-internal-handlers-db-1.5.1.zip`) from Support.
+* 1.14.3 and later 
+* 2.4.5 and later
+
+For the following agent versions, you must download and install the ZIP file manually:
+
+* 1.14.2 and earlier
+* 2.4.4 and earlier
+
+To install the ZIP file:
+
+. Request the API Analytics-Tracking Database Internal Handlers ZIP file (`mule-agent-internal-handlers-db-1.5.1.zip`) from Support.
 . Extract the ZIP file to the `{MULE_HOME}/plugins/mule-agent-plugin/lib/modules` folder.
 
 

--- a/modules/ROOT/pages/sending-api-analytics-from-arm-to-db.adoc
+++ b/modules/ROOT/pages/sending-api-analytics-from-arm-to-db.adoc
@@ -44,7 +44,7 @@ For Mule agent versions earlier than 1.14.3 and 2.4.5:
 . Extract the ZIP file to the `{MULE_HOME}/plugins/mule-agent-plugin/lib/modules` folder.
 
 
-== Agent Configurable Fields
+== Agent-Configurable Fields
 
 Once you have the latest Runtime Manager agent and the API analytics tracking database internal handlers installed on your API gateway standalone server, enable the internal handler by modifying your `{MULE_HOME}/conf/mule-agent.yml` configuration file.
 

--- a/modules/ROOT/pages/sending-event-data-from-arm-to-db.adoc
+++ b/modules/ROOT/pages/sending-event-data-from-arm-to-db.adoc
@@ -24,24 +24,27 @@ Ensure that the following software is installed:
 * Mule version 3.6 or later
 * API gateway standalone version 2.1.0 or later
 * Runtime Manager agent version 1.3.0 or later
++
+For information about updating the agent, see xref:installing-and-configuring-runtime-manager-agent.adoc[Install or Update Runtime Manager Agent].
 
-== Install or Update Runtime Manager Agent
 
-Runtime Manager agent sends messages from Mule runtime engine.
-To send event information to third-party software, you must have version 1.3.0 or later of Runtime Manager agent.
+== Install Event-Tracking Database Internal Handlers
 
-See xref:installing-and-configuring-runtime-manager-agent.adoc[Install or Update Runtime Manager Agent].
+Depending on your version of Runtime Manager agent, you might need to install the Event-Tracking Database Internal Handlers ZIP file.
 
-== Install Event Tracking Database Internal Handlers
+For the following agent versions, you don't need to install the ZIP file because the required JAR files are included in the agent plugin:
 
-Depending on your version of Mule agent, you might need to install the Event Tracking Database Internal Handlers ZIP file.
+* 1.14.3 and later 
+* 2.4.5 and later
 
-For Mule agent versions later than 1.14.3 and 2.4.5, you don't need to install the ZIP file.
-The required JAR files are included in the Mule agent plugin.
+For the following agent versions, you must download and install the ZIP file manually:
 
-For Mule agent versions earlier than 1.14.3 and 2.4.5:
+* 1.14.2 and earlier
+* 2.4.4 and earlier
 
-. Request the Event Tracking Database Internal Handlers ZIP file (`mule-agent-internal-handlers-db-1.5.1.zip`) from Support.
+To install the ZIP file:
+
+. Request the Event-Tracking Database Internal Handlers ZIP file (`mule-agent-internal-handlers-db-1.5.1.zip`) from Support.
 . Extract the ZIP file to the `{MULE_HOME}/plugins/mule-agent-plugin/lib/modules` folder.
 
 

--- a/modules/ROOT/pages/sending-event-data-from-arm-to-db.adoc
+++ b/modules/ROOT/pages/sending-event-data-from-arm-to-db.adoc
@@ -5,38 +5,45 @@ endif::[]
 
 :keywords: analytics, monitoring, logs, mule events, logging, apy analytics, metrics, traceability, arm, anypoint runtime manager, db, sql, mysql, oracle, jdbc
 
-image:logo-cloud-disabled.png[link="/runtime-manager/deployment-strategies", title="CloudHub"]
-image:logo-hybrid-active.png[link="/runtime-manager/deployment-strategies", title="Hybrid Deployment"]
-image:logo-server-active.png[link="/runtime-manager/deployment-strategies", title="Anypoint Platform Private Cloud Edition"]
-image:logo-pcf-disabled.png[link="/runtime-manager/deployment-strategies", title="Pivotal Cloud Foundry"]
+image:logo-cloud-disabled.png[link="/runtime-manager/deployment-strategies#cloudhub", title="CloudHub"]
+image:logo-hybrid-active.png[link="/runtime-manager/deployment-strategies#hybrid", title="Hybrid"]
+image:logo-server-active.png[link="/runtime-manager/deployment-strategies#anypoint-platform-private-cloud-edition", title="Anypoint Platform PCE"]
+image:logo-rtf-disabled.png[link="/runtime-manager/deployment-strategies#anypoint-runtime-fabric", title="Runtime Fabric"]
 
-By simply configuring a few settings, the event notifications produced by your running Mule applications can be easily stored in a database.
 
-[NOTE]
-====
-Sending data to third-party software is a feature that is currently only available for applications deployed to local servers. It is not available for applications that you deploy via the Runtime Manager to xref:cloudhub.adoc[CloudHub]. See xref:deployment-strategies.adoc[Deployment Strategies]xref:deployment-strategies.adoc[Deployment Strategies].
+You can configure Runtime Manager agent to store the event notifications from Mule apps in a database.
 
-It's not available either for applications deployed to Pivotal Cloud Foundry (PCF).
-====
+Sending data to third-party software is only available for applications deployed to local servers.
+It is not supported for applications that you deploy to CloudHub using Runtime Manager.
+
 
 == Prerequisites
 
-Please make sure you have the following software installed:
+Ensure that the following software is installed:
 
-* Mule – version 3.6 or above
-* API gateway standalone – version 2.1.0 or above, if you deal with apps that are built with the API gateway
-* The Runtime Manager agent plugin version 1.3.0 or above
+* Mule version 3.6 or later
+* API gateway standalone version 2.1.0 or later
+* Runtime Manager agent version 1.3.0 or later
 
-== Install the Runtime Manager Agent
+== Install or Update Runtime Manager Agent
 
-First you must install the Runtime Manager Agent, which is in charge of sending messages out of Mule. In order to send event information to third party software, you need to have version 1.3.0 or later of the Runtime Manager Agent.
+Runtime Manager agent sends messages from Mule runtime engine.
+To send event information to third-party software, you must have version 1.3.0 or later of Runtime Manager agent.
 
-See xref:installing-and-configuring-runtime-manager-agent.adoc[installing and configuring Runtime Manager Agent].
-
+See xref:installing-and-configuring-runtime-manager-agent.adoc[Install or Update Runtime Manager Agent].
 
 == Install Event Tracking Database Internal Handlers
 
-Download the API Analytics Tracking Database Internal Handlers from *http://mule-agent.s3.amazonaws.com/1.5.1/mule-agent-internal-handlers-db-1.5.1.zip[here]* and unzip them on `{MULE_HOME}/plugins/mule-agent-plugin/lib/modules` folder.
+Depending on your version of Mule agent, you might need to install the Event Tracking Database Internal Handlers ZIP file.
+
+For Mule agent versions later than 1.14.3 and 2.4.5, you don't need to install the ZIP file.
+The required JAR files are included in the Mule agent plugin.
+
+For Mule agent versions earlier than 1.14.3 and 2.4.5:
+
+. Request the Event Tracking Database Internal Handlers ZIP file (`mule-agent-internal-handlers-db-1.5.1.zip`) from Support.
+. Extract the ZIP file to the `{MULE_HOME}/plugins/mule-agent-plugin/lib/modules` folder.
+
 
 == Agent Configurable Fields
 
@@ -295,10 +302,10 @@ CREATE INDEX FK_MULE_EVENTS_BUSINESS_IDX ON MULE_EVENTS_BUSINESS (event_id);
 
 == See Also
 
-* xref:monitoring.adoc[Monitoring Applications]
-* xref:sending-data-from-arm-to-external-analytics-software.adoc[Send data from Runtime Manager to External Analytics Software]
-* xref:managing-servers.adoc[Managing Servers]
-* xref:deploying-to-your-own-servers.adoc[Deploy Applications to your Own Servers]
-* xref:managing-deployed-applications.adoc[Managing Deployed Applications]
+* xref:monitoring.adoc[Monitoring Applications and Servers]
+* xref:sending-data-from-arm-to-external-analytics-software.adoc[Export Data to External Analytics Tools]
+* xref:managing-servers.adoc[Servers, Server Groups, and Clusters]
+* xref:deploying-to-your-own-servers.adoc[Deploying to Your Own Servers]
+* xref:managing-deployed-applications.adoc[Manage Deployed Applications]
 * xref:managing-applications-on-your-own-servers.adoc[Managing Applications on Your Own Servers]
-* A https://anypoint.mulesoft.com/exchange/portals/anypoint-platform/f1e97bc6-315a-4490-82a7-23abe036327a.anypoint-platform/arm-rest-services[REST API] is also available for deployment to your servers.
+* https://anypoint.mulesoft.com/exchange/portals/anypoint-platform/f1e97bc6-315a-4490-82a7-23abe036327a.anypoint-platform/arm-rest-services[REST API]

--- a/modules/ROOT/pages/sending-event-data-from-arm-to-db.adoc
+++ b/modules/ROOT/pages/sending-event-data-from-arm-to-db.adoc
@@ -13,7 +13,7 @@ image:logo-rtf-disabled.png[link="/runtime-manager/deployment-strategies#anypoin
 
 You can configure Runtime Manager agent to store the event notifications from Mule apps in a database.
 
-Sending data to third-party software is only available for applications deployed to local servers.
+Sending data to third-party software is available only for applications deployed to local servers.
 It is not supported for applications that you deploy to CloudHub using Runtime Manager.
 
 


### PR DESCRIPTION
Cleaned up the intro up to the download section, added icons, addressed bug, and updated See Also links.

The bug fix is on lines 36-44 of the analytics topic.