### PR TITLE
Update lb-cert-upload.adoc

### DIFF
--- a/modules/ROOT/pages/lb-cert-upload.adoc
+++ b/modules/ROOT/pages/lb-cert-upload.adoc
@@ -57,6 +57,24 @@ cloudhub load-balancer ssl-endpoint add myLB_name example-com-crt.pem example-co
 ----
 
 
+== Replace a Certificate on an Existing Load Balancer
+
+You can replace a certificate on an existing DLB when the certificate is expiring or needs to be updated.
+
+To replace a certificate using Runtime Manager:
+
+. From Anypoint Platform, click *Runtime Manager*.
+. Click *Load Balancers*, and then click the load balancer name.
+. In the *Certificates* tab, click the certificate name.
+. Select *Choose File* to upload the public key and private key files, such as:
+
+** Public key file: `new-example-com-crt.pem`
+** Private key file: `new-example-com-private.pem`
+
+. Click *Done Editing*.
+. Click *Apply Changes*.
+
+
 == See Also
 
 * xref:lp-ssl-endpoints[Configure SSL Endpoints]


### PR DESCRIPTION
Adding instructions for replacing a certificate. This is a common task when certs are expiring.