### PR TITLE
Update runtime-manager-api.adoc for DOCS-7092

### DIFF
--- a/modules/ROOT/pages/runtime-manager-api.adoc
+++ b/modules/ROOT/pages/runtime-manager-api.adoc
@@ -6,7 +6,7 @@ endif::[]
 
 The Runtime Manager REST API enables you to programmatically access much of the functionality provided by Runtime Manager. To deploy Mule applications using the Runtime Manager REST API, see https://anypoint.mulesoft.com/exchange/portals/anypoint-platform/f1e97bc6-315a-4490-82a7-23abe036327a.anypoint-platform/arm-rest-services[REST APIs].
 
-For a more complete reference of all the operations that are supported through the API, see https://anypoint.mulesoft.com/apiplatform/anypoint-platform/#/portals/organizations/ae639f94-da46-42bc-9d51-180ec25cf994/apis/38784/versions/5567732/pages/182845[API Reference 1.26].
+For a more complete reference of all the operations that are supported through the API, see https://anypoint.mulesoft.com/exchange/portals/anypoint-platform/f1e97bc6-315a-4490-82a7-23abe036327a.anypoint-platform/arm-rest-services/[API Reference 1.23].
 
 Also note that there is a xref:cloudhub-api.adoc[CloudHub API] that allows you to deploy applications to CloudHub.
 


### PR DESCRIPTION
Please confirm detail on DOCS-7092.
We should update API Reference link from Portal to Exchnage.
