### PR TITLE
Update vpc-provisioning-concept.adoc

### DIFF
--- a/modules/ROOT/pages/vpc-provisioning-concept.adoc
+++ b/modules/ROOT/pages/vpc-provisioning-concept.adoc
@@ -54,7 +54,7 @@ For each worker deployed to CloudHub, the following IP assignation takes place:
 * A few IP addresses are reserved for infrastructure.
 * At least two IP addresses per worker to perform at zero-downtime.
 
-Due to this structure, the smallest network subnet block you can assign for your Anypoint VPC is /24 and the largest /16. +
+Due to this structure, the smallest network subnet block you can assign for your Anypoint VPC is /24 and the largest /16.
 
 The safe rule of thumb for deciding the size of your Anypoint VPC subnet is to calculate 10 times the maximum number of expected apps to deploy in the VPC.
 

--- a/modules/ROOT/pages/vpc-provisioning-concept.adoc
+++ b/modules/ROOT/pages/vpc-provisioning-concept.adoc
@@ -55,9 +55,6 @@ For each worker deployed to CloudHub, the following IP assignation takes place:
 * At least two IP addresses per worker to perform at zero-downtime.
 
 Due to this structure, the smallest network subnet block you can assign for your Anypoint VPC is /24 and the largest /16. +
-A /24 CIDR notation subnet has 256 IP addresses. +
-Reserving one IP address for the network and one for broadcast leaves you with 254 hosts for your worker. These get divided into four availability zones of 62 hosts each. Consider that each worker potentially needs two IP addresses for zero downtime, which leaves around 30 IP addresses to assign to your workers. +
-Consider also the environments required in a VPC.  For example, if you need space for 300 instances each in Dev, QA, and UAT, you need to size for 1024 instances at minimum.
 
 The safe rule of thumb for deciding the size of your Anypoint VPC subnet is to calculate 10 times the maximum number of expected apps to deploy in the VPC.
 


### PR DESCRIPTION
Removing these lines as they are incorrect/misleading:
A /24 CIDR notation subnet has 256 IP addresses. 
Reserving one IP address for the network and one for broadcast leaves you with 254 hosts for your worker. These get divided into four availability zones of 62 hosts each. Consider that each worker potentially needs two IP addresses for zero downtime, which leaves around 30 IP addresses to assign to your workers. 
Consider also the environments required in a VPC.  For example, if you need space for 300 instances each in Dev, QA, and UAT, you need to size for 1024 instances at minimum.