### PR TITLE
Update managing-cloudhub-specific-settings.adoc

### DIFF
--- a/modules/ROOT/pages/managing-cloudhub-specific-settings.adoc
+++ b/modules/ROOT/pages/managing-cloudhub-specific-settings.adoc
@@ -51,7 +51,7 @@ Only running applications count for vCores processing usage. `Stopped` applicati
 
 == Changing Your Plan
 
-To change your plan, you can contact your account representative or file a support ticket.
+To change your plan, you can contact your account representative or your Customer Success Manager.
 
 == See Also
 


### PR DESCRIPTION
Support can’t help with this and will redirect to Account representative. CSM is better alternative.