### PR TITLE
Add note that monitoring needs to be reinstalled if agent is updated

### DIFF
--- a/modules/ROOT/pages/installing-and-configuring-runtime-manager-agent.adoc
+++ b/modules/ROOT/pages/installing-and-configuring-runtime-manager-agent.adoc
@@ -112,7 +112,7 @@ When you run `amc_setup` with the `-U` parameter, you can't include other parame
 . Restart Mule or the API gateway runtime.
 
 If you update the Runtime Manager agent, you must also run the Anypoint Monitoring agent uninstall script and then re-install the Anypoint Monitoring agent.
-See xref:monitoring::am-installing.adoc#update-the-monitoring-agent[Update the Anypoint Monitoring Agent].
+See xref:monitoring::am-installing.adoc#update-the-anypoint-monitoring-agent[Update the Anypoint Monitoring Agent].
 
 
 === What Happens When You Update the Agent

--- a/modules/ROOT/pages/installing-and-configuring-runtime-manager-agent.adoc
+++ b/modules/ROOT/pages/installing-and-configuring-runtime-manager-agent.adoc
@@ -112,6 +112,7 @@ When you run `amc_setup` with the `-U` parameter, you can't include other parame
 . Restart Mule or the API gateway runtime.
 
 If you update the Runtime Manager agent, you must also run the Anypoint Monitoring agent uninstall script and then re-install the Anypoint Monitoring agent.
+See xref:monitoring::am-installing.adoc#update-the-monitoring-agent[Update the Anypoint Monitoring Agent].
 
 
 === What Happens When You Update the Agent

--- a/modules/ROOT/pages/installing-and-configuring-runtime-manager-agent.adoc
+++ b/modules/ROOT/pages/installing-and-configuring-runtime-manager-agent.adoc
@@ -111,6 +111,8 @@ To update an existing Runtime Manager agent:
 When you run `amc_setup` with the `-U` parameter, you can't include other parameters on the command line.
 . Restart Mule or the API gateway runtime.
 
+NOTE: If you update the Runtime Manager agent, you must execute the Anypoint Monitoring agent uninstall script and then re-install the Anypoint Monitoring agent.
+
 
 === What Happens When You Update the Agent
 

--- a/modules/ROOT/pages/installing-and-configuring-runtime-manager-agent.adoc
+++ b/modules/ROOT/pages/installing-and-configuring-runtime-manager-agent.adoc
@@ -111,7 +111,7 @@ To update an existing Runtime Manager agent:
 When you run `amc_setup` with the `-U` parameter, you can't include other parameters on the command line.
 . Restart Mule or the API gateway runtime.
 
-NOTE: If you update the Runtime Manager agent, you must execute the Anypoint Monitoring agent uninstall script and then re-install the Anypoint Monitoring agent.
+If you update the Runtime Manager agent, you must also run the Anypoint Monitoring agent uninstall script and then re-install the Anypoint Monitoring agent.
 
 
 === What Happens When You Update the Agent


### PR DESCRIPTION
As per this docs https://docs.mulesoft.com/release-notes/monitoring/anypoint-monitoring-installer-release-notes the monitoring installation needs to be reinstalled when upgrading the agent. So this note should be in the agent upgrade section (or both). So when you complete the upgrade of the agent, you know that you have to re-install monitoring. 

(add a link to docs on instructions on how to uninstall script and install agent)