### PR TITLE
Documentation changes for Keep URL Encoding revert

### DIFF
--- a/modules/ROOT/pages/lb-architecture.adoc
+++ b/modules/ROOT/pages/lb-architecture.adoc
@@ -68,9 +68,9 @@ The internal HTTP mode lets you configure how HTTP requests are managed. They ar
 
 == DLB URL Encoding
 
-You can configure the DLB to pass request URIs unchanged or decoded: 
+You can configure the DLB to pass request URIs unchanged or decoded:
 
-* If you select *Keep URL encoding*, the DLB passes the entire request URI to the CloudHub worker as is (unchanged).
+* If you select *Keep URL encoding*, the DLB passes only the %20 and %23 characters as is.
 * If you deselect *Keep URL encoding*, the DLB decodes the encoded part of the request URI before passing it to the CloudHub worker.
 
 == See Also

--- a/modules/ROOT/pages/lb-create-arm.adoc
+++ b/modules/ROOT/pages/lb-create-arm.adoc
@@ -60,7 +60,7 @@ Redirects the request to the same URL using the HTTPS protocol.
 . Specify options:
 +
 * *Disable Static IPs* specifies to use dynamic IPs, which do not persist when the DLB restarts.
-* *Keep URL encoding* specifies to pass the entire request URI to the CloudHub worker as is (unchanged).
+* *Keep URL encoding* specifies the DLB passes only the %20 and %23 characters as is.
 +
 If you deselect this option, the DLB decodes the encoded part of the request URI before passing it to the CloudHub worker.
 +


### PR DESCRIPTION
Updated documentation to revert to original feature description. 

Earlier feature description was completely missing on the documentation.
