### PR TITLE
AZ distance update

### DIFF
--- a/modules/ROOT/pages/cloudhub-hadr.adoc
+++ b/modules/ROOT/pages/cloudhub-hadr.adoc
@@ -23,7 +23,7 @@ Anypoint Virtual Private Cloud (Anypoint VPC) is set up at the region level. If 
 
 == Anypoint CloudHub Default Deployment Model
 
-If the application uses multiple workers, CloudHub deploys the workers in separate availability zones by default, providing HA across availability zones. The distance between the availability zones is variable and generally doesn't exceed 350 miles.
+If the application uses multiple workers, CloudHub deploys the workers in separate availability zones by default, providing HA across availability zones. The distance between the availability zones is variable but all are within 60 miles (100 km) of each other.
 
 image::hadr-am-web-services.png[]
 


### PR DESCRIPTION
AZ distance is not aligned with the AWS docs.
https://aws.amazon.com/about-aws/global-infrastructure/regions_az/

"AZ’s are physically separated by a meaningful distance, many kilometers, from any other AZ, although all are within 100 km (60 miles) of each other."