### PR TITLE
Changed from RTF name to Hybrid ID.

### DIFF
--- a/modules/ROOT/pages/anypoint-platform-cli-commands.adoc
+++ b/modules/ROOT/pages/anypoint-platform-cli-commands.adoc
@@ -509,7 +509,7 @@ Besides the default `--help`, `-f`/`--fields` and `-o`/`--output` options, this 
 |Value |Description | Example
 | `target <id>`
 | Hybrid or RTF deployment target ID. +
-| `api-mgr api deploy --target ES5 643404`
+| `api-mgr api deploy --target 1598794 643404`
 
 | `applicationName <name>`
 | Application name


### PR DESCRIPTION
From docs-feedback: the "target" parameter accepts ONLY an ID, and the example provided is a Runtime Fabric NAME