### PR TITLE
Cloudhub pattern needs to be MM-dd HH:mm:ss.SSS to let Log-Entries ap…

### DIFF
--- a/modules/ROOT/pages/custom-log-appender.adoc
+++ b/modules/ROOT/pages/custom-log-appender.adoc
@@ -85,7 +85,7 @@ Sends log data to the filesystem of the VM.
                 serverHeartbeatSendIntervalMs="${sys:logging.serverHeartbeatSendIntervalMs}"
                 statisticsPrintIntervalMs="${sys:logging.statisticsPrintIntervalMs}">
 
-            <PatternLayout pattern="[%d{MM-dd HH:mm:ss}] %-5p %c{1} [%t]: %m%n"/>
+            <PatternLayout pattern="[%d{MM-dd HH:mm:ss.SSS}] %-5p %c{1} [%t]: %m%n"/>
         </Log4J2CloudhubLogAppender>
     </Appenders>
     <Loggers>


### PR DESCRIPTION
…pear

With MM-dd HH:mm:ss nothing comes out of the API where you can download the log-files.
With MM-dd HH:mm:ss.SSS the log-entries appear as expected.