### PR TITLE
Update lb-cert-upload.adoc

### DIFF
--- a/modules/ROOT/pages/lb-cert-upload.adoc
+++ b/modules/ROOT/pages/lb-cert-upload.adoc
@@ -13,6 +13,8 @@ When you create a dedicated load balancer (DLB), you must add at least one certi
 You can add additional certificates to a DLB using Runtime Manager or the command-line interface.
 
 The certificate must be contained in one unencrypted, PEM-encoded file.
+Convert all end of line characters to Linux convention (no '\r' characters).
+If migrating a certificate from Windows tools, then remove all "Bag Attributes" and "Key Attributes".
 
 This file must contain the entire certificate chain ordered sequentially: 
 

--- a/modules/ROOT/pages/lb-cert-upload.adoc
+++ b/modules/ROOT/pages/lb-cert-upload.adoc
@@ -13,8 +13,10 @@ When you create a dedicated load balancer (DLB), you must add at least one certi
 You can add additional certificates to a DLB using Runtime Manager or the command-line interface.
 
 The certificate must be contained in one unencrypted, PEM-encoded file.
-Convert all end of line characters to Linux convention (no '\r' characters).
-If migrating a certificate from Windows tools, then remove all "Bag Attributes" and "Key Attributes".
+If you are migrating a certificate created with Windows tools:
+
+* Remove all "Bag Attributes" and "Key Attributes".
+* Convert all end-of-line characters from `\r\n` to `\n`, if necessary.
 
 This file must contain the entire certificate chain ordered sequentially: 
 


### PR DESCRIPTION
Added requirements for DLB certificates.

This is to prevent future support cases such as 00258348, where customers use invalid formats in their certificates.