### PR TITLE
Update managing-applications-on-cloudhub.adoc

### DIFF
--- a/modules/ROOT/pages/managing-applications-on-cloudhub.adoc
+++ b/modules/ROOT/pages/managing-applications-on-cloudhub.adoc
@@ -79,7 +79,7 @@ By default, all applications are limited to no more than four workers of any siz
 
 == Download a Copy of Your Deployed Application
 
-The application most recently deployed is always available for download from the console. Select the *Properties* tab on the application *Settings* page, then click *Choose file*. Specify a location on your computer to save the file.
+The application most recently deployed is always available for download from the console. Select the application link below the Application File on the application *Settings* page, then click *Choose file*. Specify a location on your computer to save the file.
 
 image::downloadappfile.png[DownloadAppFile]
 

--- a/modules/ROOT/pages/managing-applications-on-cloudhub.adoc
+++ b/modules/ROOT/pages/managing-applications-on-cloudhub.adoc
@@ -79,7 +79,7 @@ By default, all applications are limited to no more than four workers of any siz
 
 == Download a Copy of Your Deployed Application
 
-The application most recently deployed is always available for download from the console.
+The most recently deployed application archive is always available for download from the console.
 To download the application archive, click the link in *Application File* on the application *Settings* page.
 
 image::downloadappfile.png[DownloadAppFile]

--- a/modules/ROOT/pages/managing-applications-on-cloudhub.adoc
+++ b/modules/ROOT/pages/managing-applications-on-cloudhub.adoc
@@ -79,7 +79,8 @@ By default, all applications are limited to no more than four workers of any siz
 
 == Download a Copy of Your Deployed Application
 
-The application most recently deployed is always available for download from the console. Select the application link below the Application File on the application *Settings* page, then click *Choose file*. Specify a location on your computer to save the file.
+The application most recently deployed is always available for download from the console.
+To download the application archive, click the link in *Application File* on the application *Settings* page.
 
 image::downloadappfile.png[DownloadAppFile]
 


### PR DESCRIPTION
In the link https://docs.mulesoft.com/runtime-manager/managing-applications-on-cloudhub#download-a-copy-of-your-deployed-application, It says Select the Properties tab on the application Settings page, then click Choose file. Specify a location on your computer to save the file.  It is not present in the Properties tab section, Instead, it has to say Select the application link below the Application File on the application Settings page, then click Choose file. It is corrected to reflect that.