### PR TITLE
docs: Add documentation for using ConnApps in the CLI to authenticate to Anypoint

### DIFF
--- a/modules/ROOT/pages/anypoint-platform-cli.adoc
+++ b/modules/ROOT/pages/anypoint-platform-cli.adoc
@@ -4,12 +4,20 @@ include::_attributes.adoc[]
 endif::[]
 :keywords: administration, api, organization, users, gateway, theme, cli
 
-Anypoint Platform provides a scripting and command line tool for both Anypoint Platform and Anypoint Platform Private Cloud Edition.
-The CLI supports both interactive shell and standard CLI modes, and works with:
+image:logo-cloud-active.png[link="/runtime-manager/deployment-strategies#cloudhub", title="CloudHub"]
+image:logo-hybrid-active.png[link="/runtime-manager/deployment-strategies#hybrid", title="Hybrid"]
+image:logo-server-active.png[link="/runtime-manager/deployment-strategies#anypoint-platform-private-cloud-edition", title="Anypoint Platform PCE"]
+image:logo-rtf-disabled.png[link="/runtime-manager/deployment-strategies#anypoint-runtime-fabric", title="Runtime Fabric"]
+
+
+Anypoint Platform provides a scripting and command-line tool for both Anypoint Platform and Anypoint Platform Private Cloud Edition (Anypoint Platform PCE).
+The command-line interface (CLI) supports both the interactive shell and standard CLI modes and works with:
 
 * xref:exchange::index.adoc[Anypoint Exchange]
 * xref:access-management::index.adoc[Access Management]
-* xref:index.adoc[Runtime Manager] for Mule applications deployed to CloudHub (hosted by MuleSoft) and customer-hosted Mule runtimes
+* xref:index.adoc[Runtime Manager]
++
+Mule applications deployed to CloudHub (hosted by MuleSoft) and customer-hosted Mule runtimes
 * xref:virtual-private-cloud.adoc[VPCs]
 * xref:cloudhub-dedicated-load-balancer.adoc[CloudHub Load Balancers]
 * xref:2.x@api-manager::index.adoc[API Manager 2.x (Crowd Release)]
@@ -50,75 +58,81 @@ git config --global url."https://".insteadOf git://
 
 == Authentication
 
-There are three ways to configure Anypoint-CLI with credentials: Username and Password, Client ID and Client Secret, or a bearer token.
-At least one way must be provided.
+The three ways to configure Anypoint CLI with credentials are username and password, client ID and client secret, or a bearer token.
+At least one method is required.
 
 === Username and Password
 
-If your user does not log in using xref:access-management::external-identity.adoc[SSO], you can use your username and password
-with the CLI directly.
+If you don't log in using single sign-on (SSO), you can use your username and password to log into the CLI directly.
 
 [%header%autowidth.spread,cols="a,a"]
 |===
 | Parameter | Description
-| `username` | Your Anypoint Platform username.
+| `username` | Your Anypoint Platform username
 
-You can also pass this value using a the environment variable `export ANYPOINT_USERNAME=<name>`
-| `password` | Your Anypoint Platform password.
+You can also pass this value using the environment variable `export ANYPOINT_USERNAME=<name>`.
+| `password` | Your Anypoint Platform password
 
-You can also pass this value using the environment variable `export ANYPOINT_PASSWORD=<pwd>`
+You can also pass this value using the environment variable `export ANYPOINT_PASSWORD=<pwd>`.
 |===
+
+For information about logging in using SSO, see xref:access-management::external-identity.adoc[About Identity Management].
 
 === Client ID and Client Secret
 
-You can configure a xref:access-management::connected-apps-overview.adoc[Connected App] with the `client_credentials` grant
-type to use with the CLI.
+You can configure a Connected App with the `client_credentials` grant type to use with the CLI.
 
 [%header%autowidth.spread,cols="a,a"]
 |===
 | Parameter | Description
 | `client_id` | The ID of the Connected App
 
-You can also pass this value using a the environment variable `export ANYPOINT_CLIENT_ID=<client_id>`
-| `client_secret` | The Client Secret of the Connected Application
+You can also pass this value using the environment variable `export ANYPOINT_CLIENT_ID=<client_id>`.
+| `client_secret` | The client secret of the Connected App
 
-You can also pass this value using the environment variable `export ANYPOINT_CLIENT_SECRET=<client_secret>`
+You can also pass this value using the environment variable `export ANYPOINT_CLIENT_SECRET=<client_secret>`.
 |===
+
+For more information about Connected Apps, see xref:access-management::connected-apps-overview.adoc[Connected Apps].
 
 === Bearer Token
 
-If you have already https://help.mulesoft.com/s/article/How-to-generate-your-Authorization-Bearer-token-for-Anypoint-Platform[generated a bearer token]
-you may pass it in to the CLI directly. When a bearer token is provided, the CLI will ignore any provided user or client credentials.
+If you have already generated a bearer token, you can pass it to the CLI directly.
+When you provide a bearer token, the CLI ignores any provided user or client credentials.
 
 [%header%autowidth.spread,cols="a,a"]
 |===
 | Parameter | Description
-| `bearer` | A bearer token for the Anypoint platform.
+| `bearer` | A bearer token for the Anypoint Platform
 
 Your CLI session expires when the bearer token expires.
 |===
 
+For information about generating a bearer token, see https://help.mulesoft.com/s/article/How-to-generate-your-Authorization-Bearer-token-for-Anypoint-Platform[How to generate your Authorization Bearer token for Anypoint Platform].
+
+
 == Reference
 
-Every instance of Anypoint-CLI takes any of the following optional arguments:
+The Anypoint CLI takes the following optional arguments:
 
 [%header%autowidth.spread,cols="a,a"]
 |===
 |Parameter |Description
-| `organization` | Your organization within Anypoint Platform.
+| `organization` | Your organization within Anypoint Platform
 
-You can also pass this value using the environment variable `export ANYPOINT_ORG=<name>`
+You can also pass this value using the environment variable `export ANYPOINT_ORG=<name>`.
 
-| `environment` | Your Anypoint environment.
+| `environment` | Your Anypoint environment
 
-You can also pass this value using the environment variable `export ANYPOINT_ENV=<name>`
+You can also pass this value using the environment variable `export ANYPOINT_ENV=<name>`.
 
-| `host` | The host of your Anypoint Platform Installation. +
+| `host` | The host of your Anypoint Platform Installation +
 By default, this value points to +https://anypoint.mulesoft.com+. +
-If you are using Anypoint Platform Private Cloud Edition make sure to pass the address where you are hosting the platform.
-If you are using Anypoint Platform EU Cloud, make sure you pass your EU control plane URL.
 
-You can also pass this value using a dedicated environment variable `ANYPOINT_HOST=<name>`
+* If you are using Anypoint Platform PCE, pass the address where you are hosting the platform.
+* If you are using Anypoint Platform EU Cloud, pass your EU control plane URL.
+
+You can also pass this value using a dedicated environment variable `ANYPOINT_HOST=<name>`.
 
 |===
 
@@ -185,7 +199,7 @@ If you choose to pass the credentials when running `anypoint-cli`, pass both par
 
 === CLI Options
 
-If you choose to pass only your username, Anypoint-CLI prompts for your password.
+If you pass only your username, the Anypoint CLI prompts for your password.
 
 [source,text,linenums]
 ----
@@ -200,13 +214,15 @@ See xref:anypoint-platform-cli-commands.adoc[Anypoint Platform CLI 3.x List of C
 
 == Considerations
 
-A few considerations to keep in mind while using Anypoint-CLI:
+A few considerations to keep in mind while using the Anypoint CLI:
 
 . Environment variables override credentials file parameters and Command line parameters override environment variables. +
 If you don't pass a command line parameter, the default profile properties are used.
-. If you don't set an environment, you will be automatically sent to `production`. +
-. Your Anypoint session expires based on the *Default session timeout* configured in your xref:access-management::organization.adoc#manage-the-master-organization-s-settings[Master Organization's settings]. +
-. Anypoint-CLI works with autocomplete. You can start typing the name of the command or parameter and hit `tab` for an autocomplete, or double tap `tab` for a list of all possible options.
+. If not specified, the default environment is production. +
+. Your Anypoint session expires based on the *Default session timeout* configured in your Master Organization settings.
++
+For information about Master Organization settings, see xref:access-management::organization.adoc#manage-the-master-organization-s-settings[Manage Master Organization Settings].
+. The Anypoint CLI works with autocomplete. You can start typing the name of the command or parameter and press Tab for autocomplete or press Tab+Tab for a list of options.
 
 == See Also
 

--- a/modules/ROOT/pages/anypoint-platform-cli.adoc
+++ b/modules/ROOT/pages/anypoint-platform-cli.adoc
@@ -48,48 +48,81 @@ If the git protocol is blocked, you can configure Git to use `https://` instead 
 git config --global url."https://".insteadOf git://
 ----
 
+== Authentication
+
+There are three ways to configure Anypoint-CLI with credentials: Username and Password, Client ID and Client Secret, or a bearer token.
+At least one way must be provided.
+
+=== Username and Password
+
+If your user does not log in using xref:access-management::external-identity.adoc[SSO], you can use your username and password
+with the CLI directly.
+
+[%header%autowidth.spread,cols="a,a"]
+|===
+| Parameter | Description
+| `username` | Your Anypoint Platform username.
+
+You can also pass this value using a the environment variable `export ANYPOINT_USERNAME=<name>`
+| `password` | Your Anypoint Platform password.
+
+You can also pass this value using the environment variable `export ANYPOINT_PASSWORD=<pwd>`
+|===
+
+=== Client ID and Client Secret
+
+You can configure a xref:access-management::connected-apps-overview.adoc[Connected App] with the `client_credentials` grant
+type to use with the CLI.
+
+[%header%autowidth.spread,cols="a,a"]
+|===
+| Parameter | Description
+| `client_id` | The ID of the Connected App
+
+You can also pass this value using a the environment variable `export ANYPOINT_CLIENT_ID=<client_id>`
+| `client_secret` | The Client Secret of the Connected Application
+
+You can also pass this value using the environment variable `export ANYPOINT_CLIENT_SECRET=<client_secret>`
+|===
+
+=== Bearer Token
+
+If you have already https://help.mulesoft.com/s/article/How-to-generate-your-Authorization-Bearer-token-for-Anypoint-Platform[generated a bearer token]
+you may pass it in to the CLI directly. When a bearer token is provided, the CLI will ignore any provided user or client credentials.
+
+[%header%autowidth.spread,cols="a,a"]
+|===
+| Parameter | Description
+| `bearer` | A bearer token for the Anypoint platform.
+
+Your CLI session expires when the bearer token expires.
+|===
 
 == Reference
 
-Every instance of Anypoint-CLI takes any of the following options:
+Every instance of Anypoint-CLI takes any of the following optional arguments:
 
-[%header%autowidth.spread,cols="a,a,a"]
+[%header%autowidth.spread,cols="a,a"]
 |===
-|Parameter |Description | Required
-| `username` | Your Anypoint Platform username.
-
-You can also pass this value using a the environment variable `export ANYPOINT_USERNAME=<name>` | Yes
-
-| `password` | Your Anypoint Platform password.
-
-You can also pass this value using the environment variable `export ANYPOINT_PASSWORD=<pwd>` | Yes
-
+|Parameter |Description
 | `organization` | Your organization within Anypoint Platform.
 
-You can also pass this value using the environment variable `export ANYPOINT_ORG=<name>` | No
+You can also pass this value using the environment variable `export ANYPOINT_ORG=<name>`
 
 | `environment` | Your Anypoint environment.
 
-You can also pass this value using the environment variable `export ANYPOINT_ENV=<name>` | No
+You can also pass this value using the environment variable `export ANYPOINT_ENV=<name>`
 
 | `host` | The host of your Anypoint Platform Installation. +
 By default, this value points to +https://anypoint.mulesoft.com+. +
 If you are using Anypoint Platform Private Cloud Edition make sure to pass the address where you are hosting the platform.
 If you are using Anypoint Platform EU Cloud, make sure you pass your EU control plane URL.
 
-You can also pass this value using a dedicated environment variable `ANYPOINT_HOST=<name>` | No
+You can also pass this value using a dedicated environment variable `ANYPOINT_HOST=<name>`
 
-| `bearer` | Instead of passing your username and password, you can choose to pass the token for your account. +
-You can get the token for your account by hitting the +https://anypoint.mulesoft.com/accounts/login+ endpoint with your username and password to get your bearer value.
-
-Your session expires when the token bearer expires. +
-If you send both username and password, and the token bearer, the CLI prioritizes the bearer login.
-| No
 |===
 
 == Usage
-
-=== Logging In
 
 === Credentials File
 
@@ -111,6 +144,13 @@ The recommended way of passing these options to your Anypoint Platform CLI insta
  "otherProfile": {
   "username": "",
   "password": "",
+  "organization": "",
+  "environment": "",
+  "host": ""
+ },
+ "connAppProfile": {
+  "client_id": "",
+  "client_secret": "",
   "organization": "",
   "environment": "",
   "host": ""
@@ -145,7 +185,7 @@ If you choose to pass the credentials when running `anypoint-cli`, pass both par
 
 === CLI Options
 
-As instructed above, the username and password parameters are required. However, if you choose to pass your username, Anypoint Platform CLI prompts for your password.
+If you choose to pass only your username, Anypoint-CLI prompts for your password.
 
 [source,text,linenums]
 ----

--- a/modules/ROOT/pages/anypoint-platform-cli.adoc
+++ b/modules/ROOT/pages/anypoint-platform-cli.adoc
@@ -14,10 +14,10 @@ Anypoint Platform provides a scripting and command-line tool for both Anypoint P
 The command-line interface (CLI) supports both the interactive shell and standard CLI modes and works with:
 
 * xref:exchange::index.adoc[Anypoint Exchange]
-* xref:access-management::index.adoc[Access Management]
-* xref:index.adoc[Runtime Manager]
+* xref:access-management::index.adoc[Access management]
+* xref:index.adoc[Anypoint Runtime Manager]
 +
-Mule applications deployed to CloudHub (hosted by MuleSoft) and customer-hosted Mule runtimes
+Use Runtime Manager to manage Mule applications deployed to CloudHub (hosted by MuleSoft) and locally hosted Mule servers.
 * xref:virtual-private-cloud.adoc[VPCs]
 * xref:cloudhub-dedicated-load-balancer.adoc[CloudHub Load Balancers]
 * xref:2.x@api-manager::index.adoc[API Manager 2.x (Crowd Release)]
@@ -127,7 +127,7 @@ You can also pass this value using the environment variable `export ANYPOINT_ORG
 You can also pass this value using the environment variable `export ANYPOINT_ENV=<name>`.
 
 | `host` | The host of your Anypoint Platform Installation +
-By default, this value points to +https://anypoint.mulesoft.com+. +
+By default, this value points to `\https://anypoint.mulesoft.com`. +
 
 * If you are using Anypoint Platform PCE, pass the address where you are hosting the platform.
 * If you are using Anypoint Platform EU Cloud, pass your EU control plane URL.

--- a/modules/ROOT/pages/anypoint-platform-cli.adoc
+++ b/modules/ROOT/pages/anypoint-platform-cli.adoc
@@ -58,7 +58,7 @@ git config --global url."https://".insteadOf git://
 
 == Authentication
 
-The three ways to configure Anypoint CLI with credentials are username and password, client ID and client secret, or a bearer token.
+You can configure Anypoint CLI authentication with username and password, client ID and client secret, or a bearer token.
 At least one method is required.
 
 === Username and Password
@@ -122,7 +122,7 @@ The Anypoint CLI takes the following optional arguments:
 
 You can also pass this value using the environment variable `export ANYPOINT_ORG=<name>`.
 
-| `environment` | Your Anypoint environment
+| `environment` | Your Anypoint Platform environment
 
 You can also pass this value using the environment variable `export ANYPOINT_ENV=<name>`.
 


### PR DESCRIPTION
Anypoint CLI version `3.3.0` adds support for using [Connected Apps](https://docs.mulesoft.com/access-management/connected-apps-overview) to authenticate with the platform. 

`3.3.0` has been in prerelease state for a while (you need to install with `npm i -g anypoint-cli@3.3.0`, not `@latest`) but will likely be generally released within a few weeks. 

This PR updates the documentation to match the error / help message printed by the CLI.
```
$ anypoint-cli -h
    _                            _       _   ____  _       _    __
   / \   _ __  _   _ _ __   ___ (_)_ __ | |_|  _ \| | __ _| |_ / _| ___  _ __ _ __ ___
  / _ \ | '_ \| | | | '_ \ / _ \| | '_ \| __| |_) | |/ _` | __| |_ / _ \| '__| '_ ` _ \
 / ___ \| | | | |_| | |_) | (_) | | | | | |_|  __/| | (_| | |_|  _| (_) | |  | | | | | |
/_/   \_\_| |_|\__, | .__/ \___/|_|_| |_|\__|_|   |_|\__,_|\__|_|  \___/|_|  |_| |_| |_|
               |___/|_|                                                                   CLI v3.3.0


ERROR: At least one authorization mechanism (bearer, username, or client_id) must be specified.


Error: required parameters not set
Required:
  (username, password) OR
  (client_id, client_secret) OR
  bearer
Optional:
  organization
  environment
  host

Parameters are loaded from one of the profiles in ~/.anypoint/credentials, which has the form
{
 "default": {
  "username": "",
  "password": ""
 },
 "otherProfile": {
  "username": "",
  "password": "",
  "organization": "",
  "environment": "",
  "host": ""
 },
 "connAppProfile": {
  "client_id": "",
  "client_secret": "",
  "organization": "",
  "environment": "",
  "host": ""
 }
}
The 'default' profile is used unless the ANYPOINT_PROFILE env variable is set.

Environment variables override credentials file parameters:
  ANYPOINT_USERNAME, ANYPOINT_PASSWORD, ANYPOINT_CLIENT_ID, ANYPOINT_CLIENT_SECRET, ANYPOINT_ORG, ANYPOINT_ENV, ANYPOINT_BEARER

Command line parameters override environment variables:
  --username, --password, --client_id, --client_secret, --organization, --environment, --bearer

If a 'password' parameter is not included when a username is supplied, you will be prompted for one.
```