### PR TITLE
Patch/ION-9115-copy-command

### DIFF
--- a/modules/ROOT/pages/_partials/hidden-props.adoc
+++ b/modules/ROOT/pages/_partials/hidden-props.adoc
@@ -1,4 +1,4 @@
 //HIDDEN PROPS XREF
 //tag::hidePropsXref[]
-For information about safely hidden application properties, see  xref:secure-application-properties.adoc[Safely Hide Application Properties].
+For information about safely hidden application properties, see xref:secure-application-properties.adoc[Safely Hide Application Properties].
 // end::hidePropsXref[]

--- a/modules/ROOT/pages/_partials/hidden-props.adoc
+++ b/modules/ROOT/pages/_partials/hidden-props.adoc
@@ -1,0 +1,4 @@
+//HIDDEN PROPS XREF
+//tag::hidePropsXref[]
+For information about safely hidden application properties, see  xref:secure-application-properties.adoc[Safely Hide Application Properties].
+// end::hidePropsXref[]

--- a/modules/ROOT/pages/anypoint-platform-cli-commands.adoc
+++ b/modules/ROOT/pages/anypoint-platform-cli-commands.adoc
@@ -1590,7 +1590,7 @@ The property to be set must be passed enclosed in quotes and characters `:` and 
 |===
 
 [NOTE]
-When copying an application containing xref:secure-application-properties.adoc[secure properties], the secure properties need to be passed in the copy command using the
+When copying an application containing xref:secure-application-properties.adoc[safely hidden application properties], the safely hidden application properties need to be passed in the copy command using the
 `--property` option.
 
 

--- a/modules/ROOT/pages/anypoint-platform-cli-commands.adoc
+++ b/modules/ROOT/pages/anypoint-platform-cli-commands.adoc
@@ -1586,7 +1586,7 @@ In addition to the default `--help`, `-f`/`--fields` and `-o`/`--output` options
 |Option |Description
 |--property  | Set a property (`name:value`). Can be specified multiple times.
 
-Enclose the property to set in quotes. Escape the `:` and `=` characters,
+Enclose the property in quotes and escape the `:` and `=` characters,
 for example:
 
 `--property "salesforce.password:qa\=34534"`

--- a/modules/ROOT/pages/anypoint-platform-cli-commands.adoc
+++ b/modules/ROOT/pages/anypoint-platform-cli-commands.adoc
@@ -1579,22 +1579,23 @@ If the Anypoint Platform CLI is using the QA environment in the Services organiz
 [NOTE]
 Running this command requires your user to have read/write access to the `/tmp` directory of the OS where CLI is installed.
 
-The options this command can take are:
+In addition to the default `--help`, `-f`/`--fields` and `-o`/`--output` options, this command also takes:
 
 [%header,cols="30a,70a"]
 |===
 |Option |Description
-|--property                                    | Set a property (`name:value`). Can be specified multiple times. +
-The property to be set must be passed enclosed in quotes and characters `:` and `=` must be escaped. +
-(e.g. `--property "salesforce.password:qa\=34534"`)
+|--property  | Set a property (`name:value`). Can be specified multiple times.
+
+Enclose the property to set in quotes. Escape the `:` and `=` characters,
+for example:
+
+`--property "salesforce.password:qa\=34534"`
 |===
 
 [NOTE]
-When copying an application containing xref:secure-application-properties.adoc[safely hidden application properties], the safely hidden application properties need to be passed in the copy command using the
-`--property` option.
-
-
-This command also takes the default options: `--help`, `-f`/`--fields` and `-o`/`--output`.
+When copying an application containing safely hidden application properties, pass them `copy` command using the `--property` option.
+//HIDDEN PROPS XREF 
+include::partial$hidden-props.adoc[tag=hidePropsXref]
 
 === runtime-mgr rtf list
 

--- a/modules/ROOT/pages/anypoint-platform-cli-commands.adoc
+++ b/modules/ROOT/pages/anypoint-platform-cli-commands.adoc
@@ -1579,7 +1579,22 @@ If the Anypoint Platform CLI is using the QA environment in the Services organiz
 [NOTE]
 Running this command requires your user to have read/write access to the `/tmp` directory of the OS where CLI is installed.
 
-This command does not take any options, except for the default ones: `--help`, `-f`/`--fields` and `-o`/`--output`.
+The options this command can take are:
+
+[%header,cols="30a,70a"]
+|===
+|Option |Description
+|--property                                    | Set a property (`name:value`). Can be specified multiple times. +
+The property to be set must be passed enclosed in quotes and characters `:` and `=` must be escaped. +
+(e.g. `--property "salesforce.password:qa\=34534"`)
+|===
+
+[NOTE]
+When copying an application containing xref:secure-application-properties.adoc[secure properties], the secure properties need to be passed in the copy command using the
+`--property` option.
+
+
+This command also takes the default options: `--help`, `-f`/`--fields` and `-o`/`--output`.
 
 === runtime-mgr rtf list
 

--- a/modules/ROOT/pages/anypoint-platform-cli-commands.adoc
+++ b/modules/ROOT/pages/anypoint-platform-cli-commands.adoc
@@ -1593,7 +1593,7 @@ for example:
 |===
 
 [NOTE]
-When copying an application containing safely hidden application properties, pass them `copy` command using the `--property` option.
+When copying an application containing safely hidden application properties, pass the properties in the `copy` command using the `--property` option.
 //HIDDEN PROPS XREF 
 include::partial$hidden-props.adoc[tag=hidePropsXref]
 

--- a/modules/ROOT/pages/deploying-to-cloudhub.adoc
+++ b/modules/ROOT/pages/deploying-to-cloudhub.adoc
@@ -201,7 +201,7 @@ that are currently deployed to CloudHub to other CloudHub workers.
 For example, you can't move an app that is currently deployed on a local server to CloudHub.
 . If you want to copy the environment variables and Mule version from the source application, select *Merge environment variables and mule version*.
 +
-If your source application contains any xref:secure-application-properties.adoc[secure properties], you need to *redefine* them under the properties tab.
+If your source application contains any xref:secure-application-properties.adoc[safely hidden application properties], you need to *redefine* them under the properties tab.
 . Click *Apply*.
 . Click tabs to configure application options.
 +

--- a/modules/ROOT/pages/deploying-to-cloudhub.adoc
+++ b/modules/ROOT/pages/deploying-to-cloudhub.adoc
@@ -201,7 +201,9 @@ that are currently deployed to CloudHub to other CloudHub workers.
 For example, you can't move an app that is currently deployed on a local server to CloudHub.
 . If you want to copy the environment variables and Mule version from the source application, select *Merge environment variables and mule version*.
 +
-If your source application contains any xref:secure-application-properties.adoc[safely hidden application properties], you need to *redefine* them under the properties tab.
+If your source application contains safely hidden application properties, you must redefine them in the *Properties* tab.
+//HIDDEN PROPS XREF 
+include::partial$hidden-props.adoc[tag=hidePropsXref]
 . Click *Apply*.
 . Click tabs to configure application options.
 +

--- a/modules/ROOT/pages/deploying-to-cloudhub.adoc
+++ b/modules/ROOT/pages/deploying-to-cloudhub.adoc
@@ -200,6 +200,8 @@ Only applications that are deployed to CloudHub appear in the list because you c
 that are currently deployed to CloudHub to other CloudHub workers. 
 For example, you can't move an app that is currently deployed on a local server to CloudHub.
 . If you want to copy the environment variables and Mule version from the source application, select *Merge environment variables and mule version*.
++
+If your source application contains any xref:secure-application-properties.adoc[secure properties], you need to *redefine* them under the properties tab.
 . Click *Apply*.
 . Click tabs to configure application options.
 +


### PR DESCRIPTION
Jira ticket: [ ION-9115](https://www.mulesoft.org/jira/browse/ION-9115
) - Anypoint CLI - copy command line does not work with secure properties. 

We are enforcing that customers would have to redefine 'safely hidden application properties' every time they make a copy of an application (either from the UI or the CLI). In order to do that we modified the CLI copy command to accept a property option. 

Updating the docs for the same.
