### PR TITLE
Correction on asset page delete command

### DIFF
--- a/modules/ROOT/pages/anypoint-platform-cli-commands.adoc
+++ b/modules/ROOT/pages/anypoint-platform-cli-commands.adoc
@@ -1248,7 +1248,6 @@ This command does not take any options, except for the default ones: `--help`, `
 ----
 
 This command deletes the description page specified in `<pageName>`, for the asset identified with `<assetIdentifier>`. +
-If `<pageName>` is not specified, this command downloads all pages.
 
 [WARNING]
 This command does not prompt twice before deleting. If you send a delete instruction, it does not ask for confirmation.


### PR DESCRIPTION
The `asset page delete` command had a comment that was taken from the `asset page download` command which did not apply. 