### PR TITLE
W-12632105: Adding warning about enabling scripting languages for custom logging configurations in CH1.

### DIFF
--- a/cloudhub-1/modules/ROOT/pages/custom-log-appender.adoc
+++ b/cloudhub-1/modules/ROOT/pages/custom-log-appender.adoc
@@ -109,7 +109,7 @@ You must include the appenders in your custom configurations in the `log4j2.xml`
 ----
 
 [WARNING]
-If you need to use https://logging.apache.org/log4j/2.x/manual/configuration.html#scripts[scripts] in your `log4j2.xml` custom configuration, make sure to enable the languages you are using by setting the `log4j2.Script.enableLanguages` system property accordingly. You can enable multiple languages by providing a comma separated list of values. For example: `log4j2.Script.enableLanguages=js,groovy`.
+If you need to use https://logging.apache.org/log4j/2.x/manual/configuration.html#scripts[scripts^] in your `log4j2.xml` custom configuration, make sure to enable the languages you use by setting the `log4j2.Script.enableLanguages` system property accordingly. You can enable multiple languages by providing a comma-separated list of values. For example, `log4j2.Script.enableLanguages=js,groovy`.
 
 == Enable Custom Log4j Configurations in CloudHub
 

--- a/cloudhub-1/modules/ROOT/pages/custom-log-appender.adoc
+++ b/cloudhub-1/modules/ROOT/pages/custom-log-appender.adoc
@@ -108,6 +108,8 @@ You must include the appenders in your custom configurations in the `log4j2.xml`
 </Configuration>
 ----
 
+[WARNING]
+If you need to use https://logging.apache.org/log4j/2.x/manual/configuration.html#scripts[scripts] in your `log4j2.xml` custom configuration, make sure to enable the languages you are using by setting the `log4j2.Script.enableLanguages` system property accordingly. You can enable multiple languages by providing a comma separated list of values. For example: `log4j2.Script.enableLanguages=js,groovy`.
 
 == Enable Custom Log4j Configurations in CloudHub
 


### PR DESCRIPTION
# Context for this PR

There was a regression found in the February monthly cycle ([W-12517872](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00001KxVftYAF/view)) which was caused by a patch version upgrade of log4j from 2.17.1 to 2.17.2 which included a [backwards breaking change](https://issues.apache.org/jira/browse/LOG4J2-2486): scripting is now disabled by default. In order to [enable scripting languages](https://logging.apache.org/log4j/2.x/manual/configuration.html#scripts), a system property must be set with a comma separated list of the corresponding languages.

We are now advising our customers who may be using custom logging configuration with scripts to set that system property accordingly to enable the languages they need.

# Writer's Quality Checklist

Before merging your PR, did you:

- [x] Run spell checker
- [x] Run link checker to check for broken xrefs
- [x] Check for orphan files
- [x] Perform a local build and do a final visual check of your content, including checking for:
  - Broken images
  - Dead links
  - Correct rendering of partials if they are used in your content
  - Formatting issues, such as:
    - Misnumbered ordered lists (steps) or incorrectly nested unordered lists
    - Messed up tables
    - Proper indentation
    - Correct header levels
- [x] Receive final review and signoff from:
  - Technical SME
  - Product Manager
  - Editor or peer reviewer
  - Reporter, if this content is in response to a reported issue (internal or external feedback)
- [ ] If applicable, verify that the software actually got released