### PR TITLE
W-21553100: Update MuleSoft Help Center links to Salesforce Help

### DIFF
--- a/cloudhub/modules/ROOT/pages/cloudhub-faq.adoc
+++ b/cloudhub/modules/ROOT/pages/cloudhub-faq.adoc
@@ -37,7 +37,7 @@ For specific pricing, reach out to either your account executive or your account
 
 == How do I get support?
 
-The CloudHub team is committed to providing the best customer experience possible. Contact the CloudHub team in the https://help.mulesoft.com[MuleSoft Help Center].
+The CloudHub team is committed to providing the best customer experience possible. Contact the CloudHub team in the https://help.salesforce.com[Salesforce Help].
 
 You can browse and search the online https://help.mulesoft.com/s/forum[forum] to find answers. Or post a question and start a new thread.
 
@@ -104,7 +104,7 @@ Environment variables are properties you can set to pass in configuration to you
 
 == Can I deploy my application to a different region?
 
-Yes! Visit https://help.mulesoft.com[MuleSoft Help Center] to file a support case to enable global deployments for your account. Applications can be deployed to: US East (N. Virginia, Ohio), US West (N. California, Oregon), Canada, South America (Brazil - Sao Paulo), Europe (Ireland, Frankfurt), UK (London), and Asia-Pacific (Sydney, Tokyo, Singapore). Administrators can  xref:managing-cloudhub-specific-settings.adoc[set the default region] on the *Organization* tab in Account Settings, but that region can be adjusted when the application is deployed, if necessary.
+Yes! Visit https://help.salesforce.com[Salesforce Help] to file a support case to enable global deployments for your account. Applications can be deployed to: US East (N. Virginia, Ohio), US West (N. California, Oregon), Canada, South America (Brazil - Sao Paulo), Europe (Ireland, Frankfurt), UK (London), and Asia-Pacific (Sydney, Tokyo, Singapore). Administrators can  xref:managing-cloudhub-specific-settings.adoc[set the default region] on the *Organization* tab in Account Settings, but that region can be adjusted when the application is deployed, if necessary.
 
 Note that the domains of applications deployed to different regions are automatically updated to reflect the region.
 

--- a/cloudhub/modules/ROOT/pages/cloudhub-networking-guide.adoc
+++ b/cloudhub/modules/ROOT/pages/cloudhub-networking-guide.adoc
@@ -80,7 +80,7 @@ You can access these IP addresses through the `mule-worker-internal-myapp.region
 
 CloudHub IP addresses are chosen from the Amazon EC2 IP pool. For a list of these ranges, see https://docs.aws.amazon.com/vpc/latest/userguide/aws-ip-ranges.html[Amazon AWS IP Address Ranges API]. The download link in that page will retrieve a dynamically generated JSON representation of all ranges that include the region. These ranges can change without notice, so you should update this information regularly.
 
-CloudHub supports allocating a static IP for applications so that they can be allowlisted for other services. To enable a static IP for your application, go to the *Static IPs* tab in the application settings page on the Runtime Manager UI, then enable the *Use Static IP* checkbox. By default, you are allocated a number of static IPs equal to twice the number of Production vCores in your subscription. To increase this limit, contact https://help.mulesoft.com[MuleSoft Help Center].
+CloudHub supports allocating a static IP for applications so that they can be allowlisted for other services. To enable a static IP for your application, go to the *Static IPs* tab in the application settings page on the Runtime Manager UI, then enable the *Use Static IP* checkbox. By default, you are allocated a number of static IPs equal to twice the number of Production vCores in your subscription. To increase this limit, contact https://help.salesforce.com[Salesforce Help].
 
 After a static IP has been allocated for your application, the IP address is visible in the *Static IPs* tab in the application settings. For more information about static IPs, see xref:deploying-to-cloudhub.adoc#static-ips-tab-settings[Static IPs Tab Settings].
 

--- a/cloudhub/modules/ROOT/pages/developing-applications-for-cloudhub.adoc
+++ b/cloudhub/modules/ROOT/pages/developing-applications-for-cloudhub.adoc
@@ -78,7 +78,7 @@ use the xref:mule-runtime::logger-component-reference.adoc[Logger component].
 [IMPORTANT]
 On CloudHub, after you delete an application, your log data is no longer accessible through the console. CloudHub archives old log data for a limited period of time before it is purged,
 so you can recover the data if needed.
-For more information, open a support case at https://help.mulesoft.com[MuleSoft Help Center].
+For more information, open a support case at https://help.salesforce.com[Salesforce Help].
 
 == Package Third-Party Libraries
 

--- a/cloudhub/modules/ROOT/pages/managing-applications-on-cloudhub.adoc
+++ b/cloudhub/modules/ROOT/pages/managing-applications-on-cloudhub.adoc
@@ -74,7 +74,7 @@ You can dynamically scale your applications by selecting options from the *Worke
 image::workersize.png[WorkerSize]
 
 [IMPORTANT]
-By default, all applications are limited to no more than four workers of any size. Free and professional accounts are limited to a single worker per app. If you need more workers or more total vCore capacity, update your subscription. If you need more than four workers for a single domain, https://help.mulesoft.com[MuleSoft Help Center] directly.
+By default, all applications are limited to no more than four workers of any size. Free and professional accounts are limited to a single worker per app. If you need more workers or more total vCore capacity, update your subscription. If you need more than four workers for a single domain, https://help.salesforce.com[Salesforce Help] directly.
 
 == Download a Copy of Your Deployed Application
 

--- a/runtime-manager/modules/ROOT/pages/managing-deployed-applications.adoc
+++ b/runtime-manager/modules/ROOT/pages/managing-deployed-applications.adoc
@@ -122,7 +122,7 @@ Deletes the application.
 If you’re deploying your application to an on-premises cluster, Runtime Manager starts/stops/deletes the application simultaneously on each server.
 
 [IMPORTANT]
-On CloudHub, after you delete an application, your log data is no longer accessible from the console. CloudHub archives old log data for a limited period of time before it is purged. This allows you to recover the data if needed. Open a support case at: https://help.mulesoft.com[MuleSoft Help Center] for more information.
+On CloudHub, after you delete an application, your log data is no longer accessible from the console. CloudHub archives old log data for a limited period of time before it is purged. This allows you to recover the data if needed. Open a support case at: https://help.salesforce.com[Salesforce Help] for more information.
 
 
 [[status_states]]


### PR DESCRIPTION
Updates all "https://help.mulesoft.com[MuleSoft Help Center]" references to "https://help.salesforce.com[Salesforce Help]" and removes the ^ from link text.