### PR TITLE
W-21648093-ch2-new-wording-kt

### DIFF
--- a/cloudhub/modules/ROOT/pages/app-migration.adoc
+++ b/cloudhub/modules/ROOT/pages/app-migration.adoc
@@ -38,7 +38,7 @@ The *Deployment Target* field shows the preselected private space for the applic
 You can’t edit this field.
 . For *Application File*, you can either:
 +
-* Upload your application file: Download the application asset from the link under *Application File*, make the necessary changes, and upload it to deploy your new application to the CloudHub 2.0 private space.
+* Upload your application file: Download the application asset from the link under *Application File*, make the necessary changes, and upload it to deploy your application to the CloudHub 2.0 private space.
 * Import file from Exchange: Import the CloudHub application you want to upgrade.
 . In the *Ingress* tab, specify the *Endpoint* configuration:
 .. Select a *Host* from the dropdown list.
@@ -60,12 +60,12 @@ In applications with inbound traffic, the Shared Load Balancer (SLB) handles tra
 ====
 
 [NOTE]
-The *Host* dropdown list shows only the domains initially added under the certificates of the underlying VPC's DLB configuration. If you add a new certificate to the original VPC's DLB after the application upgrade starts, add it manually under the *Domain & TLS* tab of your newly created private space for that domain to appear on the *Host* dropdown list.
+The *Host* dropdown list shows only the domains initially added under the certificates of the underlying VPC's DLB configuration. If you add a new certificate to the original VPC's DLB after the application upgrade starts, add it manually under the *Domain & TLS* tab of your CloudHub 2.0 private space for that domain to appear on the *Host* dropdown list.
 
 
 === Considerations and Limitations
 
-The upgrade process doesn’t automatically map some configuration settings to the new CloudHub 2.0 application. 
+The upgrade process doesn’t automatically map some configuration settings to the CloudHub 2.0 application. 
 
 ==== Application Properties 
 
@@ -80,7 +80,7 @@ To manage a migrated app using the Mule Maven plugin (MMP), copy the public URL 
 
 ==== CloudHub Application Default Domain
 
-When deploying a new CloudHub 2.0 application, avoid using the CloudHub default domain to prevent issues such as traffic outages.
+When deploying a CloudHub 2.0 application, avoid using the CloudHub default domain to prevent issues such as traffic outages.
 
 
 == Next Steps After Application Upgrade
@@ -214,7 +214,7 @@ Autodiscovery connects a deployed Mule application with an API defined in API Ma
 
 After traffic fully redirects to the CloudHub 2.0 application, stop your CloudHub application within 30 days and mark the upgrade as complete. 
 
-If you change your CloudHub application after it stops, the changes aren't replicated in your new CloudHub 2.0 application. Make any required changes to the CloudHub 2.0 application settings. 
+If you change your CloudHub application after it stops, the changes aren't replicated in your CloudHub 2.0 application. Make any required changes to the CloudHub 2.0 application settings. 
 
 After your CloudHub application stops, delete it within 30 days. 
 
@@ -236,7 +236,7 @@ To perform a DLB failover:
 
 . For each DLB linked to your upgraded VPC, go to the DLB settings page and click *Failover to CloudHub 2.0*. 
 +
-This fails over the `anypointdns.net` domain to CloudHub 2.0, removes any additional DLB hop, and redirects traffic to your new CloudHub 2.0 private space URL.
+This fails over the `anypointdns.net` domain to CloudHub 2.0, removes any additional DLB hop, and redirects traffic to your CloudHub 2.0 private space URL.
 
 . After the traffic failover completes, stop and delete the CloudHub DLB linked to the VPC.
 

--- a/cloudhub/modules/ROOT/pages/app-migration.adoc
+++ b/cloudhub/modules/ROOT/pages/app-migration.adoc
@@ -60,7 +60,7 @@ In applications with inbound traffic, the Shared Load Balancer (SLB) handles tra
 ====
 
 [NOTE]
-The *Host* dropdown list shows only the domains initially added under the certificates of the underlying VPC's DLB configuration. If you add a new certificate to the original VPC's DLB after the application upgrade starts, add it manually under the *Domain & TLS* tab of your new private space for that domain to appear on the *Host* dropdown list.
+The *Host* dropdown list shows only the domains initially added under the certificates of the underlying VPC's DLB configuration. If you add a new certificate to the original VPC's DLB after the application upgrade starts, add it manually under the *Domain & TLS* tab of your newly created private space for that domain to appear on the *Host* dropdown list.
 
 
 === Considerations and Limitations

--- a/cloudhub/modules/ROOT/pages/app-migration.adoc
+++ b/cloudhub/modules/ROOT/pages/app-migration.adoc
@@ -38,7 +38,7 @@ The *Deployment Target* field shows the preselected private space for the applic
 You can’t edit this field.
 . For *Application File*, you can either:
 +
-* Upload your application file: Download the application asset from the link under *Application File*, make the necessary changes, and upload it to deploy your application to the new private space.
+* Upload your application file: Download the application asset from the link under *Application File*, make the necessary changes, and upload it to deploy your new application to the private space.
 * Import file from Exchange: Import the CloudHub application you want to upgrade.
 . In the *Ingress* tab, specify the *Endpoint* configuration:
 .. Select a *Host* from the dropdown list.

--- a/cloudhub/modules/ROOT/pages/app-migration.adoc
+++ b/cloudhub/modules/ROOT/pages/app-migration.adoc
@@ -38,7 +38,7 @@ The *Deployment Target* field shows the preselected private space for the applic
 You can’t edit this field.
 . For *Application File*, you can either:
 +
-* Upload your application file: Download the application asset from the link under *Application File*, make the necessary changes, and upload it to deploy your application to the CloudHub 2.0 private space.
+* Upload your application file: Download the application asset from the link under *Application File*, make the necessary changes, and upload it to deploy your application to the new private space.
 * Import file from Exchange: Import the CloudHub application you want to upgrade.
 . In the *Ingress* tab, specify the *Endpoint* configuration:
 .. Select a *Host* from the dropdown list.
@@ -60,7 +60,7 @@ In applications with inbound traffic, the Shared Load Balancer (SLB) handles tra
 ====
 
 [NOTE]
-The *Host* dropdown list shows only the domains initially added under the certificates of the underlying VPC's DLB configuration. If you add a new certificate to the original VPC's DLB after the application upgrade starts, add it manually under the *Domain & TLS* tab of your CloudHub 2.0 private space for that domain to appear on the *Host* dropdown list.
+The *Host* dropdown list shows only the domains initially added under the certificates of the underlying VPC's DLB configuration. If you add a new certificate to the original VPC's DLB after the application upgrade starts, add it manually under the *Domain & TLS* tab of your new private space for that domain to appear on the *Host* dropdown list.
 
 
 === Considerations and Limitations

--- a/cloudhub/modules/ROOT/pages/ch-ch2-migration-completion.adoc
+++ b/cloudhub/modules/ROOT/pages/ch-ch2-migration-completion.adoc
@@ -17,7 +17,7 @@ After you mark the upgrade complete, CloudHub 2.0 replaces all CloudHub resource
 
 == Entitlements for VPCs, Private Spaces, and Network Connections (VPNs/TGW)
 
-After you complete the VPC upgrade and bring over any existing TGW and VPN network connections, your old and new infrastructure count separately against your usage. Therefore, if your organization uses all purchased quota, your usage can exceed the allowed quota until you move all your applications to CloudHub 2.0 and decommission your old VPC.
+After you complete the VPC upgrade and bring over any existing TGW and VPN network connections, your CloudHub and CloudHub 2.0 infrastructure count separately against your usage. Therefore, if your organization uses all purchased quota, your usage can exceed the allowed quota until you move all your applications to CloudHub 2.0 and decommission your old VPC.
 
 Work with your account representative to plan for additional entitlements, and decommission your CloudHub infrastructure (VPCs and associated DLBs) within six months after the upgrade to avoid interruptions when trying to create or edit VPCs, private spaces, or network connections.
 

--- a/cloudhub/modules/ROOT/pages/vpc-upgrade.adoc
+++ b/cloudhub/modules/ROOT/pages/vpc-upgrade.adoc
@@ -1,11 +1,11 @@
 = CloudHub VPC to CloudHub 2.0 Private Space Upgrade  
 
 //Overview
-To migrate your workloads from CloudHub to CloudHub 2.0, you must set up your CloudHub 2.0 infrastructure and network connections. One approach is to create CloudHub 2.0 private spaces with configurations that differ from your existing CloudHub setup. 
+To migrate your workloads from CloudHub to CloudHub 2.0, you must set up your CloudHub 2.0 infrastructure and network connections. One approach is to create new CloudHub 2.0 private spaces with configurations that differ from your existing CloudHub setup. 
 
 To retain your infrastructure configuration, use the in-product VPC upgrade tool to easily migrate your CloudHub dedicated Virtual Private Cloud (VPC) to a CloudHub 2.0 private space.
 
-When your CloudHub 2.0 private space is ready, you can gradually migrate your applications from the CloudHub VPC to the CloudHub 2.0 private space. After moving all your applications, you can decommission your old VPC.
+When your new private space is ready, you can gradually migrate your applications from the CloudHub VPC to the CloudHub 2.0 private space. After moving all your applications, you can decommission your old VPC.
 
 
 // Benefits
@@ -13,7 +13,7 @@ Using the in-product VPC upgrade tool saves you time because you don't need to a
 
 The tool provisions the infrastructure for a CloudHub 2.0 private space by cloning the existing configurations of your eligible CloudHub dedicated VPC, using the same CIDR block. 
 
-If your VPC has existing Transit Gateways (TGW) or Virtual Private Networks (VPN) connections, they transfer seamlessly to the CloudHub 2.0 private space. This migration ensures that any new applications deployed to the private space can communicate effectively.
+If your VPC has existing Transit Gateways (TGW) or Virtual Private Networks (VPN) connections, they transfer seamlessly to the new CloudHub 2.0 private space. This migration ensures that any new applications deployed to the new private space can communicate effectively.
 
 The default CloudHub certificates are configured as part of the private space's default certificates. The DLB custom domains of the migrated VPC are created as part of the private space's custom TLS certificates.
 
@@ -88,8 +88,8 @@ image::upgrade-ch2-review-conf.png[VPC upgrade review page showing available con
 . Click *Next* to continue.
 . Provide a name for the new private space.
 + 
-Optionally, you can specify xref:cloudhub-2::ps-gather-setup-info.adoc#cidr-block[reserved CIDRs] to connect to your CloudHub 2.0 private space.
-. Click *Create* to create the private space.
+Optionally, you can specify xref:cloudhub-2::ps-gather-setup-info.adoc#cidr-block[reserved CIDRs] to connect to your new private space.
+. Click *Create* to create the new private space.
 +
 The *Upgrade to CloudHub 2.0* review page shows the progress of the VPC upgrade process, which takes about 15 to 30 minutes.
 
@@ -98,7 +98,7 @@ If you create a VPN to provision your CloudHub VPC, wait until the newly created
 
 As soon as the upgrade process starts, the upgraded VPC is locked for any further updates. 
 
-You can cancel the upgrade process to revert to your VPC at any time by clicking *Cancel Upgrade*. In that case, the system deletes the private space, and your VPC is unlocked.
+You can cancel the upgrade process to revert to your VPC at any time by clicking *Cancel Upgrade*. In that case, the system deletes the newly created private space, and your VPC is unlocked.
 
 After you provision the private space, the *Cancel Upgrade* button no longer shows. However, you can still roll back the upgrade by deleting the private space.
 
@@ -123,9 +123,9 @@ For the final steps after VPC upgrade and CloudHub application migration, see xr
 [NOTE]
 When deploying a CloudHub 2.0 application, avoid using the CloudHub default domain to prevent issues such as traffic outages.
 
-During the migration, you can continue to deploy and manage applications in your VPC to maintain business continuity. To prevent configuration drift, after the upgrade, your CloudHub dedicated VPC is locked for any changes to the infrastructure, including environment or business group associations, network connections, and internal DNS. Make any required changes to the CloudHub 2.0 private space. The upgrade process applies any CloudHub 2.0 configuration changes to the CloudHub VPC. 
+During the migration, you can continue to deploy and manage applications in your VPC to maintain business continuity. To prevent configuration drift, after the upgrade, your CloudHub dedicated VPC is locked for any changes to the infrastructure, including environment or business group associations, network connections, and internal DNS. Make any required changes to the newly created private space. The upgrade process applies any CloudHub 2.0 configuration changes to the CloudHub VPC. 
 
-If your CloudHub VPC doesn't have any network connections, and you create new ones in your CloudHub 2.0 private space after the upgrade, these new connections aren’t reflected in your CloudHub VPC.
+If your CloudHub VPC doesn't have any network connections, and you create new ones in your new CloudHub 2.0 private space after the upgrade, these new connections aren’t reflected in your CloudHub VPC.
 
 The firewall rules configured in your VPC are copied to the private space. After that, you can make additional changes to the firewall rules in the VPC and the private space. To avoid configuration drift, apply any firewall rule changes in both places throughout the migration.
 

--- a/cloudhub/modules/ROOT/pages/vpc-upgrade.adoc
+++ b/cloudhub/modules/ROOT/pages/vpc-upgrade.adoc
@@ -1,11 +1,11 @@
 = CloudHub VPC to CloudHub 2.0 Private Space Upgrade  
 
 //Overview
-To migrate your workloads from CloudHub to CloudHub 2.0, you must set up your CloudHub 2.0 infrastructure and network connections. One approach is to create new CloudHub 2.0 private spaces with configurations that differ from your existing CloudHub setup. 
+To migrate your workloads from CloudHub to CloudHub 2.0, you must set up your CloudHub 2.0 infrastructure and network connections. One approach is to create CloudHub 2.0 private spaces with configurations that differ from your existing CloudHub setup. 
 
 To retain your infrastructure configuration, use the in-product VPC upgrade tool to easily migrate your CloudHub dedicated Virtual Private Cloud (VPC) to a CloudHub 2.0 private space.
 
-When your new private space is ready, you can gradually migrate your applications from the CloudHub VPC to the CloudHub 2.0 private space. After moving all your applications, you can decommission your old VPC.
+When your CloudHub 2.0 private space is ready, you can gradually migrate your applications from the CloudHub VPC to the CloudHub 2.0 private space. After moving all your applications, you can decommission your old VPC.
 
 
 // Benefits
@@ -13,7 +13,7 @@ Using the in-product VPC upgrade tool saves you time because you don't need to a
 
 The tool provisions the infrastructure for a CloudHub 2.0 private space by cloning the existing configurations of your eligible CloudHub dedicated VPC, using the same CIDR block. 
 
-If your VPC has existing Transit Gateways (TGW) or Virtual Private Networks (VPN) connections, they transfer seamlessly to the new CloudHub 2.0 private space. This migration ensures that any new applications deployed to the new private space can communicate effectively.
+If your VPC has existing Transit Gateways (TGW) or Virtual Private Networks (VPN) connections, they transfer seamlessly to the CloudHub 2.0 private space. This migration ensures that any new applications deployed to the private space can communicate effectively.
 
 The default CloudHub certificates are configured as part of the private space's default certificates. The DLB custom domains of the migrated VPC are created as part of the private space's custom TLS certificates.
 
@@ -88,8 +88,8 @@ image::upgrade-ch2-review-conf.png[VPC upgrade review page showing available con
 . Click *Next* to continue.
 . Provide a name for the new private space.
 + 
-Optionally, you can specify xref:cloudhub-2::ps-gather-setup-info.adoc#cidr-block[reserved CIDRs] to connect to your new private space.
-. Click *Create* to create the new private space.
+Optionally, you can specify xref:cloudhub-2::ps-gather-setup-info.adoc#cidr-block[reserved CIDRs] to connect to your CloudHub 2.0 private space.
+. Click *Create* to create the private space.
 +
 The *Upgrade to CloudHub 2.0* review page shows the progress of the VPC upgrade process, which takes about 15 to 30 minutes.
 
@@ -98,7 +98,7 @@ If you create a VPN to provision your CloudHub VPC, wait until the newly created
 
 As soon as the upgrade process starts, the upgraded VPC is locked for any further updates. 
 
-You can cancel the upgrade process to revert to your VPC at any time by clicking *Cancel Upgrade*. In that case, the system deletes the newly created private space, and your VPC is unlocked.
+You can cancel the upgrade process to revert to your VPC at any time by clicking *Cancel Upgrade*. In that case, the system deletes the private space, and your VPC is unlocked.
 
 After you provision the private space, the *Cancel Upgrade* button no longer shows. However, you can still roll back the upgrade by deleting the private space.
 
@@ -121,11 +121,11 @@ After you migrate all the applications in a VPC, delete the VPC and any associat
 For the final steps after VPC upgrade and CloudHub application migration, see xref:ch-ch2-migration-completion.adoc[].
 
 [NOTE]
-When deploying a new CloudHub 2.0 application, avoid using the CloudHub default domain to prevent issues such as traffic outages.
+When deploying a CloudHub 2.0 application, avoid using the CloudHub default domain to prevent issues such as traffic outages.
 
-During the migration, you can continue to deploy and manage applications in your VPC to maintain business continuity. To prevent configuration drift, after the upgrade, your CloudHub dedicated VPC is locked for any changes to the infrastructure, including environment or business group associations, network connections, and internal DNS. Make any required changes to the newly created private space. The upgrade process applies any CloudHub 2.0 configuration changes to the CloudHub VPC. 
+During the migration, you can continue to deploy and manage applications in your VPC to maintain business continuity. To prevent configuration drift, after the upgrade, your CloudHub dedicated VPC is locked for any changes to the infrastructure, including environment or business group associations, network connections, and internal DNS. Make any required changes to the CloudHub 2.0 private space. The upgrade process applies any CloudHub 2.0 configuration changes to the CloudHub VPC. 
 
-If your CloudHub VPC doesn't have any network connections, and you create new ones in your new CloudHub 2.0 private space after the upgrade, these new connections aren’t reflected in your CloudHub VPC.
+If your CloudHub VPC doesn't have any network connections, and you create new ones in your CloudHub 2.0 private space after the upgrade, these new connections aren’t reflected in your CloudHub VPC.
 
 The firewall rules configured in your VPC are copied to the private space. After that, you can make additional changes to the firewall rules in the VPC and the private space. To avoid configuration drift, apply any firewall rule changes in both places throughout the migration.
 


### PR DESCRIPTION
- vpc-upgrade.adoc: replace 'new CloudHub 2.0' / 'newly created' with 'CloudHub 2.0' or 'private space'
- ch-ch2-migration-completion.adoc: 'old and new infrastructure' -> 'CloudHub and CloudHub 2.0 infrastructure'
- app-migration.adoc: remove 'new' when referring to CloudHub 2.0 application or private space

CloudHub 2.0 is no longer new; wording updated for accuracy.



# Writer's Quality Checklist

Before merging your PR, did you:

- [ ] Run spell checker
- [ ] Run link checker to check for broken xrefs
- [ ] Check for orphan files
- [ ] Perform a local build and do a final visual check of your content, including checking for:
  - Broken images
  - Dead links
  - Correct rendering of partials if they are used in your content
  - Formatting issues, such as:
    - Misnumbered ordered lists (steps) or incorrectly nested unordered lists
    - Messed up tables
    - Proper indentation
    - Correct header levels
- [ ] Receive final review and signoff from:
  - Technical SME
  - Product Manager
  - Editor or peer reviewer
  - Reporter, if this content is in response to a reported issue (internal or external feedback)
- [ ] If applicable, verify that the software actually got released