### PR TITLE
W-19861124: Remove "Accept HTTP" step from DLB HTTP traffic switching section-kt

### DIFF
--- a/cloudhub/modules/ROOT/pages/app-migration.adoc
+++ b/cloudhub/modules/ROOT/pages/app-migration.adoc
@@ -140,7 +140,6 @@ For applications using a DLB and expecting HTTPS traffic:
 
 For applications using a DLB and expecting HTTP traffic:
 
-. Enable the *Accept HTTP* option within the *Advanced* tab of your private space settings. 
 . Add a firewall rule allowing HTTP from the local private network.
 
 [WARNING]


### PR DESCRIPTION
## Summary
- Removes the "Enable the Accept HTTP option within the Advanced tab of your private space settings" step from the **DLB with HTTP Traffic Switching** section in `app-migration.adoc`.
- This step only applies to the **SLB** traffic switching scenario, not the DLB scenario. The SLB section retains the instruction.

## Test plan
- [ ] Verify the "DLB with HTTP Traffic Switching" section no longer contains the "Accept HTTP" step.
- [ ] Verify the "SLB with HTTP Traffic Switching" section still contains the "Accept HTTP" step.
- [ ] Build and preview the page to confirm correct rendering.

Resolves W-19861124

