### PR TITLE
W-21614062: Remove IBM JVM section from servers-create-kt

### DIFF
--- a/runtime-manager/modules/ROOT/pages/servers-create.adoc
+++ b/runtime-manager/modules/ROOT/pages/servers-create.adoc
@@ -61,23 +61,6 @@ After the script completes successfully, the name of your server appears on the 
 
 If the server was running when you ran the `amc_setup` script, restart the server to reconnect with Runtime Manager.
 
-== IBM JVM
-
-When creating a server using the IBM Java Virtual Machine (JVM), you must use a different truststore file than the default truststore installed by the Runtime Manager agent.
-
-. Download the custom truststore from this knowledgebase article:
-+
-// This KA is no longer available
-https://help.mulesoft.com/s/article/Connectivity-issues-between-Mule-Runtime-and-Anypoint-Runtime-manager-using-an-IBM-JVM[Connectivity issues between Mule and Anypoint Runtime Manager using an IBM JVM]
-. Depending on your Mule version, rename the `truststore` file in `$MULE_HOME/conf` to one of these file names:
-* `anypoint-truststore.jks`
-+
-Mule 4.1.3 (Agent 2.1.4) and later
-* `truststore.jks`
-+
-Mule 4.1.2 (Agent 2.1.3)
-. Copy the custom truststore into the `$MULE_HOME/conf` folder.
-. Restart Mule.
 
 == Remove a Server from Another Runtime Manager Instance
 


### PR DESCRIPTION
The IBM JVM truststore instructions and referenced KA are no longer applicable.

Made-with: Cursor

# Writer's Quality Checklist

Before merging your PR, did you:

- [ ] Run spell checker
- [ ] Run link checker to check for broken xrefs
- [ ] Check for orphan files
- [ ] Perform a local build and do a final visual check of your content, including checking for:
  - Broken images
  - Dead links
  - Correct rendering of partials if they are used in your content
  - Formatting issues, such as:
    - Misnumbered ordered lists (steps) or incorrectly nested unordered lists
    - Messed up tables
    - Proper indentation
    - Correct header levels
- [ ] Receive final review and signoff from:
  - Technical SME
  - Product Manager
  - Editor or peer reviewer
  - Reporter, if this content is in response to a reported issue (internal or external feedback)
- [ ] If applicable, verify that the software actually got released