### PR TITLE
W-22028255-ch-scheduler-idempotency-update-kt

### DIFF
--- a/cloudhub/modules/ROOT/pages/managing-schedules.adoc
+++ b/cloudhub/modules/ROOT/pages/managing-schedules.adoc
@@ -37,8 +37,9 @@ When designing the schedule, consider the following:
 +
 During service updates or security patching, CloudHub waits two minutes for existing schedules to complete.
 After two minutes, CloudHub retriggers any incomplete schedules.
+Additionally, during zero downtime deployments, schedules whose trigger time overlaps with the deployment window might be triggered more than once, even if the initial execution completed successfully.
 +
-To avoid retriggers with long-running schedules, make sure that the app executes the flow idempotently.
+To avoid retriggers with long-running schedules, and duplicate processing during deployment overlaps, make sure that the app executes the flow idempotently.
 * Design your schedules to prevent duplicate data processing, as they can be triggered more than once due to the issues mentioned previously.
 * For multi-worker apps, CloudHub guarantees that the schedule trigger executes on a single worker.
 +


### PR DESCRIPTION
Add note that schedules triggered during zero-downtime deployments may fire more than once even if the initial run completed successfully, and update the idempotency recommendation to cover deployment overlaps.


# Writer's Quality Checklist

Before merging your PR, did you:

- [ ] Run spell checker
- [ ] Run link checker to check for broken xrefs
- [ ] Check for orphan files
- [ ] Perform a local build and do a final visual check of your content, including checking for:
  - Broken images
  - Dead links
  - Correct rendering of partials if they are used in your content
  - Formatting issues, such as:
    - Misnumbered ordered lists (steps) or incorrectly nested unordered lists
    - Messed up tables
    - Proper indentation
    - Correct header levels
- [ ] Receive final review and signoff from:
  - Technical SME
  - Product Manager
  - Editor or peer reviewer
  - Reporter, if this content is in response to a reported issue (internal or external feedback)
- [ ] If applicable, verify that the software actually got released