### PR TITLE
W-22202552: Add CloudHub Network Administrator permission note for traffic switching

### DIFF
--- a/cloudhub/modules/ROOT/pages/app-migration.adoc
+++ b/cloudhub/modules/ROOT/pages/app-migration.adoc
@@ -99,6 +99,9 @@ MuleSoft-Managed:: Carry over vanity URLs while incrementally switching percenta
 [IMPORTANT]
 Restart your DLB before initiating the traffic switching.
 
+[NOTE]
+To switch application traffic, you must have the *CloudHub Network Administrator* permission. Without this permission, the traffic switching controls are not available. For more information about assigning permissions, see xref:access-management::permissions-by-product.adoc[Permissions Available in Anypoint Platform].
+
 To gradually switch traffic from CloudHub to CloudHub 2.0:
 
 . In *Runtime Manager*, go to *Finish Upgrade*.

--- a/cloudhub/modules/ROOT/pages/app-migration.adoc
+++ b/cloudhub/modules/ROOT/pages/app-migration.adoc
@@ -100,7 +100,7 @@ MuleSoft-Managed:: Carry over vanity URLs while incrementally switching percenta
 Restart your DLB before initiating the traffic switching.
 
 [NOTE]
-To switch application traffic, you must have the *CloudHub Network Administrator* permission. Without this permission, the traffic switching controls are not available. For more information about assigning permissions, see xref:access-management::permissions-by-product.adoc[Permissions Available in Anypoint Platform].
+To switch application traffic, you must have the CloudHub Network Administrator permission. Without this permission, the traffic switching controls aren't available. For more information about assigning permissions, see xref:access-management::permissions-by-product.adoc[].
 
 To gradually switch traffic from CloudHub to CloudHub 2.0:
 


### PR DESCRIPTION
## Summary
- Adds a `[NOTE]` block to the CloudHub to CloudHub 2.0 Application Migration page (`app-migration.adoc`) stating that the **CloudHub Network Administrator** permission is required for traffic switching.
- Without this permission, users cannot access the traffic switching controls.

## Test plan
- [ ] Verify the note renders correctly on the published page under the "Next Steps After Application Upgrade" section.
- [ ] Confirm the `xref` link to `permissions-by-product` resolves properly.

GUS: W-22202552


