### PR TITLE
W-22202552: Update traffic switching permission note wording

### DIFF
--- a/cloudhub/modules/ROOT/pages/app-migration.adoc
+++ b/cloudhub/modules/ROOT/pages/app-migration.adoc
@@ -100,7 +100,7 @@ MuleSoft-Managed:: Carry over vanity URLs while incrementally switching percenta
 Restart your DLB before initiating the traffic switching.
 
 [NOTE]
-To switch application traffic, you must have the CloudHub Network Administrator permission. Without this permission, the traffic switching controls aren't available. For more information about assigning permissions, see xref:access-management::permissions-by-product.adoc[].
+To switch application traffic, you must have the CloudHub Network Administrator permission. Without this permission, the traffic switching fails. For more information about assigning permissions, see xref:access-management::permissions-by-product.adoc[].
 
 To gradually switch traffic from CloudHub to CloudHub 2.0:
 


### PR DESCRIPTION
## Summary
- Updated the traffic switching permission note in `app-migration.adoc` to say "the traffic switching fails" instead of "the traffic switching controls aren't available" for accuracy.

## Test plan
- [ ] Verify the sentence reads correctly in the built page.

Made with [Cursor](https://cursor.com)