### PR TITLE
W-22854222: Add note that CH1 app must stay STARTED until CH2 link is established

### DIFF
--- a/cloudhub/modules/ROOT/pages/app-migration.adoc
+++ b/cloudhub/modules/ROOT/pages/app-migration.adoc
@@ -102,6 +102,9 @@ Restart your DLB before initiating the traffic switching.
 [NOTE]
 To switch application traffic, you must have the CloudHub Network Administrator permission. Without this permission, the traffic switching controls aren't available. For more information about assigning permissions, see xref:access-management::permissions-by-product.adoc[].
 
+[IMPORTANT]
+The CloudHub application must remain in STARTED state until the link between CloudHub and CloudHub 2.0 is successfully established. Stopping the CloudHub application before the link is established can cause traffic disruptions.
+
 To gradually switch traffic from CloudHub to CloudHub 2.0:
 
 . In *Runtime Manager*, go to *Finish Upgrade*.


### PR DESCRIPTION
## Summary

- Adds an `[IMPORTANT]` note to `app-migration.adoc` stating that the CloudHub 1.0 application must remain in STARTED state until the link between CloudHub and CloudHub 2.0 is successfully established.
- This is a best-practice clarification requested by the MS CX team (Sven Sackers) to prevent traffic disruptions during migration.

## GUS

W-22854222

## Test plan

- [ ] Review rendered adoc output for correct `[IMPORTANT]` block placement and wording
- [ ] Confirm no broken xrefs or formatting issues