### PR TITLE
W-23259913: Correct CloudHub log API time parameters (ISO 8601 UTC, not epoch)

### DIFF
--- a/cloudhub/modules/ROOT/pages/cloudhub-api-reference.adoc
+++ b/cloudhub/modules/ROOT/pages/cloudhub-api-reference.adoc
@@ -36,6 +36,8 @@ Use these endpoints to search and download application log entries.
 |`GET` |`/v2/applications/{domain}/instances/{instanceId}/log-file` |Download the log file for a specific instance.
 |===
 
+When filtering by time range, the `startTime` and `endTime` parameters require ISO 8601 UTC format with microsecond precision (`YYYY-MM-DDTHH:mm:ss.SSSSSSZ`), for example, `2025-12-25T10:00:00.000000Z`. These parameters do not accept epoch (Unix) timestamps.
+
 == Notifications and Alerts
 
 Use these endpoints to manage notifications and configure alerts for your CloudHub applications.

--- a/cloudhub/modules/ROOT/pages/cloudhub-api-reference.adoc
+++ b/cloudhub/modules/ROOT/pages/cloudhub-api-reference.adoc
@@ -36,7 +36,7 @@ Use these endpoints to search and download application log entries.
 |`GET` |`/v2/applications/{domain}/instances/{instanceId}/log-file` |Download the log file for a specific instance.
 |===
 
-When filtering by time range, the `startTime` and `endTime` parameters require ISO 8601 UTC format with microsecond precision (`YYYY-MM-DDTHH:mm:ss.SSSSSSZ`), for example, `2025-12-25T10:00:00.000000Z`. These parameters do not accept epoch (Unix) timestamps.
+When filtering by time range, the `startTime` and `endTime` parameters require ISO 8601 UTC format with microsecond precision (`YYYY-MM-DDTHH:mm:ss.SSSSSSZ`), for example, `2025-12-25T10:00:00.000000Z`. These parameters don't accept epoch (Unix) timestamps.
 
 == Notifications and Alerts
 

--- a/cloudhub/modules/ROOT/pages/viewing-log-data.adoc
+++ b/cloudhub/modules/ROOT/pages/viewing-log-data.adoc
@@ -83,6 +83,13 @@ CloudHub stores up to 100 MB of log data per application per worker, or up to 30
 
 CloudHub stores log data in Universal Time (UTC); however, the console displays the log using your computer's local time zone.
 
+== Retrieve Logs Using the CloudHub API
+
+To retrieve application logs programmatically, use the CloudHub API log endpoints.
+See xref:cloudhub-api-reference.adoc[CloudHub API Reference].
+
+When filtering by time range, the `startTime` and `endTime` parameters require ISO 8601 UTC format with microsecond precision (`YYYY-MM-DDTHH:mm:ss.SSSSSSZ`), for example, `2025-12-25T10:00:00.000000Z`. These parameters do not accept epoch (Unix) timestamps.
+
 
 == Search Logs
 

--- a/cloudhub/modules/ROOT/pages/viewing-log-data.adoc
+++ b/cloudhub/modules/ROOT/pages/viewing-log-data.adoc
@@ -88,7 +88,7 @@ CloudHub stores log data in Universal Time (UTC); however, the console displays 
 To retrieve application logs programmatically, use the CloudHub API log endpoints.
 See xref:cloudhub-api-reference.adoc[CloudHub API Reference].
 
-When filtering by time range, the `startTime` and `endTime` parameters require ISO 8601 UTC format with microsecond precision (`YYYY-MM-DDTHH:mm:ss.SSSSSSZ`), for example, `2025-12-25T10:00:00.000000Z`. These parameters do not accept epoch (Unix) timestamps.
+When filtering by time range, the `startTime` and `endTime` parameters require ISO 8601 UTC format with microsecond precision (`YYYY-MM-DDTHH:mm:ss.SSSSSSZ`), for example, `2025-12-25T10:00:00.000000Z`. These parameters don't accept epoch (Unix) timestamps.
 
 
 == Search Logs


### PR DESCRIPTION
## Summary
- Corrects documentation for the Application Manager logs/`log-file` API time parameters per GUS **W-23259913** (Case 472670023).
- Clarifies that `startTime`/`endTime` require **ISO 8601 UTC** format (`YYYY-MM-DDTHH:mm:ss.SSSSSSZ`), **not** epoch (Unix) timestamps.
- Keeps the confirmed retention limit (30 days / 100 MB per app per worker).

## Changes
- `viewing-log-data.adoc`: added a "Retrieve Logs Using the CloudHub API" section with the ISO 8601 UTC note.
- `cloudhub-api-reference.adoc`: added the same note to the Logs section, next to the log endpoint listing.

## Why
Engineers passing epoch milliseconds per the prior guidance received empty or error responses and could not retrieve logs within a time window.

## Test plan
- [ ] Verify AsciiDoc renders correctly (both sections/notes display as expected).
- [ ] Confirm no unconfirmed `/logs` vs `/logs/file` limit claim was added.

Made with [Cursor](https://cursor.com)