### PR TITLE
@W-15246887: Clarify CPU vs JVM memory metric in CloudHub autoscaling note

### DIFF
--- a/cloudhub/modules/ROOT/pages/autoscaling-in-cloudhub.adoc
+++ b/cloudhub/modules/ROOT/pages/autoscaling-in-cloudhub.adoc
@@ -36,7 +36,10 @@ image::policy-form.png[form]
 . Determine if the scaling will be based on *Memory or CPU usage*.
 +
 [NOTE]
-The percentage shown is the percentage of total memory or CPU allocated for the JVM that's being used. This includes the memory being consumed by the JVM itself.
+====
+* For *CPU*: The percentage shown is the worker's total CPU usage relative to its allocated CPU capacity. Autoscaling is triggered based on the worker's overall CPU usage, not JVM CPU usage alone.
+* For *Memory*: The percentage shown is the percentage of total memory allocated for the JVM that's being used, including memory consumed by the JVM itself.
+====
 
 . Determine the *Rules* for your scaling. You must provide the following values for both the upscale and the downscale conditions:
 .. A usage *percentage*


### PR DESCRIPTION
## Summary

- Splits the ambiguous single-line note under \"Create a Policy\" step 2 into separate CPU and Memory bullets
- Clarifies that CPU autoscaling is triggered by the worker's total CPU usage, not JVM CPU usage alone
- Preserves the accurate JVM memory description in its own bullet

## Background

W-15246887 (March 2024 doc bug) identified that the note conflated CPU and JVM-memory measurements under generic \"JVM\" language. W-22704761 tracks the docs fix after a customer opened a support case asking whether CPU autoscaling works when fractional vCore workers run out of CPU credits — confusion directly caused by the original wording.

## Test plan

- [ ] Verify note renders correctly in both bullets in the staging preview
- [ ] Confirm no broken formatting (AsciiDoc `[NOTE] ====` block syntax)