### PR TITLE
docs: note CloudHub 1.0 200 MB hard app size limit (W-23445672)

### DIFF
--- a/cloudhub/modules/ROOT/pages/deploying-to-cloudhub.adoc
+++ b/cloudhub/modules/ROOT/pages/deploying-to-cloudhub.adoc
@@ -55,6 +55,15 @@ See <<Application Names>>.
 .. Select the file to upload and then click *Open*.
 +
 The application file size limit is 200 MB.
++
+[NOTE]
+====
+The maximum CloudHub 1.0 application size is a hard limit of 200 MB (209,715,200 bytes).
+Deployments that exceed it fail with HTTP `400` and the error message `Maximum length exceeded: 209715200 Bytes`.
+You can't raise this limit.
+To reduce the deployable archive, remove unused dependencies and externalize large resources.
+Mule apps deploy as self-contained archives, so all dependencies count toward the limit.
+====
 
 ** Copy an application from a nonproduction environment.
 +


### PR DESCRIPTION
## Summary

Adds a note box on the CloudHub 1.0 deploy page clarifying that the 200 MB application size limit is a hard limit, so engineers who hit the cryptic `Maximum length exceeded: 209715200 Bytes` 400 error understand it maps to a fixed ceiling that can't be raised.

Change lands in `cloudhub/modules/ROOT/pages/deploying-to-cloudhub.adoc`, in the *Deploy an Application from Runtime Manager* step next to the existing "200 MB" mention. The note states:

- The maximum size is a hard limit of 200 MB (209,715,200 bytes).
- Deployments that exceed it fail with HTTP `400` and `Maximum length exceeded: 209715200 Bytes`.
- The limit can't be raised; reduce the archive by removing unused dependencies and externalizing large resources.
- Mule apps deploy as self-contained archives, so all dependencies count toward the limit.

GUS: https://gus.lightning.force.com/W-23445672

## Sources
- GUS W-23445672 — "Case Reduction: 3. CloudHub 1.0 200 MB application size is a HARD limit" (the doc request). Exact wording, byte value, error string, and remediation all came from the ticket's Details field.
- Referenced in the ticket (not independently opened): Org CS Case 473077228 as evidence for the customer-facing error.

## Test plan
- [ ] Verify the note renders correctly in the Antora build (admonition formatting, inline code strings).
- [ ] Confirm placement under the Runtime Manager deploy step reads well next to the existing 200 MB mention.

Made with [Cursor](https://cursor.com)