### PR TITLE
W-23446673-ch2-ch1-schedules-rest-api-kt

### DIFF
--- a/cloudhub/modules/ROOT/pages/cloudhub-api-reference.adoc
+++ b/cloudhub/modules/ROOT/pages/cloudhub-api-reference.adoc
@@ -60,6 +60,11 @@ For more information, see xref:custom-application-alerts.adoc[].
 
 Use these endpoints to view and update scheduled jobs for your CloudHub applications.
 
+[NOTE]
+====
+These schedules endpoints don't return scheduler or domain details for CloudHub 2.0 applications. To manage schedulers for CloudHub 2.0 apps, use the CloudHub 2.0 APIs or the Runtime Manager *Schedules* tab. See xref:cloudhub-2::ch2-manage-schedules.adoc[].
+====
+
 [%header,cols="10,45,45"]
 |===
 |Method |Endpoint |Description


### PR DESCRIPTION
## Summary

Documentation change for W-23446673 (Case Reduction — CloudHub schedules REST API vs. CloudHub 2.0 apps).

- **cloudhub-api-reference.adoc** — Added a note in the *Schedules* section that these CloudHub schedules endpoints don't return scheduler or domain details for CloudHub 2.0 applications, and that CH2.0 schedulers are managed through the CloudHub 2.0 APIs or the Runtime Manager Schedules tab.

## Sources

- GUS W-23446673 — doc request; wording and facts came from its Details__c.
- Evidence referenced within the ticket: Case 472652052; W-22913960 (Closed – No Fix – Working as Documented).

## Related

- Companion change in `docs-hosting` (same branch name): https://github.com/mulesoft/docs-hosting/pull/459

## Test plan

- [ ] Antora build renders the page without errors
- [ ] Note box displays correctly
- [ ] Cross-component xref to cloudhub-2::ch2-manage-schedules.adoc resolves