### PR TITLE
docs: correct DLB security header injection status codes (W-23663099)

### DIFF
--- a/cloudhub/modules/ROOT/pages/lb-reserved-headers.adoc
+++ b/cloudhub/modules/ROOT/pages/lb-reserved-headers.adoc
@@ -36,7 +36,7 @@ The CloudHub Dedicated Load Balancer (DLB) reserves and injects specific HTTP he
 Security Headers::
 +
 * The DLB enforces the security headers, and you can't override them.
-* The DLB injects the `X-Content-Type-Options`, `X-Frame-Options`, and `X-XSS-Protection` headers in the DLB response to callers for successful responses (`2xx` and `3xx` status codes).
+* The DLB injects the `X-Content-Type-Options`, `X-Frame-Options`, and `X-XSS-Protection` headers in the DLB response to callers for responses with these status codes: `200`, `201`, `204`, `206`, `301`, `302`, `303`, `304`, `307`, and `308`. These are the status codes for which the underlying NGINX `add_header` directive applies by default. Responses with other status codes, such as `202 Accepted`, don't include these headers.
 * The DLB always injects the `Strict-Transport-Security` regardless of the response code.
 
 x-ch1-path Header::


### PR DESCRIPTION
## Summary

Corrects the CloudHub Dedicated Load Balancer (DLB) security header injection documentation on the *Dedicated Load Balancer Reserved Headers* page (`docs.mulesoft.com/cloudhub/lb-reserved-headers#header-injection-rules`).

The page stated the DLB injects `X-Content-Type-Options`, `X-Frame-Options`, and `X-XSS-Protection` for all `2xx` and `3xx` responses. That's inaccurate: these headers use the default NGINX `add_header` behavior and are only added for status codes `200`, `201`, `204`, `206`, `301`, `302`, `303`, `304`, `307`, and `308`. Other status codes (for example `202 Accepted`) don't include them. `Strict-Transport-Security` is unaffected because it uses the `always` parameter (already documented).

GUS: W-23663099

## Sources
- GUS W-23663099 — the doc request; exact status-code list and replacement text from `Details__c`
- Referenced in the ticket: investigation W-23654185 and the NGINX `add_header` docs (https://nginx.org/en/docs/http/ngx_http_headers_module.html#add_header)

## Test plan
- [ ] Verify the *Header Injection Rules > Security Headers* section renders the corrected status-code list