### PR TITLE
W-23982936-ch-domain-default-clarification-kt

### DIFF
--- a/cloudhub/modules/ROOT/pages/app-migration.adoc
+++ b/cloudhub/modules/ROOT/pages/app-migration.adoc
@@ -80,7 +80,7 @@ To manage a migrated app using the Mule Maven plugin (MMP), copy the public URL 
 
 ==== CloudHub Application Default Domain
 
-When deploying a new CloudHub 2.0 application, avoid using the CloudHub default domain to prevent issues such as traffic outages.
+When deploying a new CloudHub 2.0 application during migration, don't configure it to use the inherited CloudHub default domain (the shared `+*.cloudhub.io+` endpoint in the format `<app_name>.<region>.cloudhub.io`). This domain is automatically carried over to the CloudHub 2.0 private space, but it's globally shared and can't be managed by you. Route traffic through your vanity domain or `anypointdns.net` endpoint instead. Using the default domain interferes with how traffic switching determines the traffic source (SLB versus DLB) and can cause traffic outages.
 
 
 == Next Steps After Application Upgrade

--- a/cloudhub/modules/ROOT/pages/vpc-upgrade.adoc
+++ b/cloudhub/modules/ROOT/pages/vpc-upgrade.adoc
@@ -119,7 +119,9 @@ After you migrate all the applications in a VPC, delete the VPC and any associat
 For the final steps after VPC upgrade and CloudHub application migration, see xref:ch-ch2-migration-completion.adoc[].
 
 [NOTE]
-When deploying a new CloudHub 2.0 application, avoid using the CloudHub default domain to prevent issues such as traffic outages.
+====
+When deploying a new CloudHub 2.0 application during migration, don't configure it to use the inherited CloudHub default domain (the shared `+*.cloudhub.io+` endpoint in the format `<app_name>.<region>.cloudhub.io`). This domain is automatically carried over to the CloudHub 2.0 private space, but it's globally shared and can't be managed by you. Route traffic through your vanity domain or `anypointdns.net` endpoint instead. Using the default domain interferes with how traffic switching determines the traffic source (SLB versus DLB) and can cause traffic outages.
+====
 
 During the migration, you can continue to deploy and manage applications in your VPC to maintain business continuity. To prevent configuration drift, after the upgrade, your CloudHub dedicated VPC is locked for any changes to the infrastructure, including environment or business group associations, network connections, and internal DNS. Make any required changes to the newly created private space. The upgrade process applies any CloudHub 2.0 configuration changes to the CloudHub VPC. 
 


### PR DESCRIPTION
## Summary
- Clarifies the ambiguous one-line note "avoid using the CloudHub default domain to prevent issues such as traffic outages" in the CloudHub to CloudHub 2.0 migration docs.
- Explains that the *CloudHub default domain* is the inherited, globally shared `*.cloudhub.io` endpoint (`<app_name>.<region>.cloudhub.io`), that it's automatically carried over to the CloudHub 2.0 private space and can't be customer-managed, and that customers should route through their vanity or `anypointdns.net` endpoint instead.
- Notes why using it matters: it interferes with how traffic switching infers the traffic source (SLB vs DLB) and can cause traffic outages.
- Applied to both `app-migration.adoc` and `vpc-upgrade.adoc`, which carried the identical note.

## Background
The original wording had no source ticket and was unclear to stakeholders. The clarification is based on CloudHub 2.0 engineering guidance (default domains are always migrated CH -> CH2 and "need not be used") and customer traffic-switching cases.

## Test plan
- [ ] Verify AsciiDoc renders correctly (NOTE block in `vpc-upgrade.adoc`, section paragraph in `app-migration.adoc`).
- [ ] SME/engineering confirmation of the technical explanation before publishing.